### PR TITLE
fix: disable CRA Fast Refresh to unbreak dev server

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+FAST_REFRESH=false


### PR DESCRIPTION
## Summary

- `npm start` currently fails with `Module not found: You attempted to import .../node_modules/react-refresh/runtime.js which falls outside of the project src/ directory`
- Root cause: top-level hoisted `react-refresh@0.16.0` (via `parcel` and `@pmmmwh/react-refresh-webpack-plugin`) is incompatible with the `0.11.x` that `react-scripts@5`'s `babel-preset-react-app` expects
- Verified pre-existing (reproduces on `develop` prior to #10 — not caused by the dep bumps there)
- Fix: add `.env` with `FAST_REFRESH=false`, disabling CRA's Fast Refresh plugin (the component doing the mismatched resolve). Webpack HMR still works; only React-specific fast-refresh state preservation is lost, which is fine for a demo.

The proper long-term fix is to retire `react-scripts` (deprecated, accounts for most remaining `npm audit` findings). Tracked implicitly in the deferred-majors list from #10.

## Test plan

- [x] `PORT=4001 npm start` compiles successfully
- [x] Dev server responds with HTTP 200 at `http://localhost:4001`