### PR TITLE
chore(tooling): add non-blocking Markdown link check to pre-push (#14)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,9 @@
 npm run check
+
+if command -v lychee >/dev/null 2>&1; then
+  # Non-blocking: report broken Markdown links but never block the push.
+  # External link rot and rate-limit backoffs are outside the repo's control.
+  npm run links || echo "warning: lychee reported broken links (non-blocking) — review output above."
+else
+  echo "warning: lychee not installed — skipping Markdown link check. Install with 'brew install lychee'."
+fi

--- a/docs/adr/0001-standardize-tooling-stack.md
+++ b/docs/adr/0001-standardize-tooling-stack.md
@@ -50,8 +50,16 @@ We adopt the tooling listed in issue #14 with the following scope constraints:
 - ESLint flat config pulls in sonarjs, security, unicorn, import-x, promise, n,
   jsdoc, and no-secrets on top of the existing React and a11y plugins.
 - Husky gates are layered: `pre-commit` (lint-staged + gitleaks), `commit-msg`
-  (commitlint), `pre-push` (`npm run check`), `post-merge` (audit on lockfile
-  change).
+  (commitlint), `pre-push` (`npm run check` + `lychee` Markdown link check),
+  `post-merge` (audit on lockfile change).
+- **Markdown link checking (`lychee`) runs locally at `pre-push`**, not as a
+  scheduled GitHub Action. This keeps the feedback loop local (the issue's
+  preference for Husky gates over Actions minutes) and surfaces broken links
+  before a PR is opened. The check is **non-blocking and bounded**
+  (`--max-retries 0 --timeout 10`, failure does not abort the push): external
+  link rot and host rate-limit backoffs are outside the repo's control and must
+  not be able to hang or block a developer's push. The hook also degrades
+  gracefully when `lychee` is not installed.
 - `size-limit` budgets (100 KB brotlied) enforce bundle discipline.
 - License compliance via `license-checker-rseidelsohn` with an allowlist.
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dupes:ci": "jscpd . --config .jscpd.json --threshold 5",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "links": "lychee --no-progress '**/*.md'",
+    "links": "lychee --no-progress --max-retries 0 --timeout 10 '**/*.md'",
     "size": "size-limit",
     "security:audit": "npm audit --production --audit-level=high",
     "security:osv": "osv-scanner --lockfile=package-lock.json",


### PR DESCRIPTION
## Summary

Completes the remaining link-checking acceptance item from #14. The bulk of the
tooling stack already landed on `develop` via #15; this adds the one missing
piece — local Markdown link checking via Husky.

- Adds a `lychee` Markdown link check to the `.husky/pre-push` hook so links are
  surfaced locally before a PR is opened — per the issue's preference for Husky
  gates over GitHub Actions minutes (no scheduled `docs.yml` Action).
- The check is **non-blocking and bounded** (`--max-retries 0 --timeout 10`,
  failure does not abort the push). External link rot and host rate-limit
  backoffs are outside the repo's control and must not hang or block a
  developer's push. The hook also degrades gracefully when `lychee` is not
  installed (matching the existing `gitleaks` pattern).
- Updates ADR 0001 to document the decision.

## Verification

- `npm run check:all` passes locally (exit 0): check + test (14 passing) +
  build + dupes (0 clones) + size (62.97 kB ESM / 62.79 kB CJS, under 100 kB) +
  license:check + security:audit (0 prod vulns) + security:secrets (no leaks).
- Confirmed the `pre-push` hook does not block: `npm run links` runs and reports
  broken links without failing the push.

Refs #14