### PR TITLE
fix(tooling): scope lychee link check to repo-owned markdown

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+^https?://localhost
+^https?://127\.0\.0\.1

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dupes:ci": "jscpd . --config .jscpd.json --threshold 5",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "links": "lychee --no-progress --max-retries 0 --timeout 10 '**/*.md'",
+    "links": "lychee --no-progress --max-retries 0 --timeout 10 --exclude-path node_modules --exclude-path dist --exclude-path build --exclude-path coverage '**/*.md'",
     "size": "size-limit",
     "security:audit": "npm audit --production --audit-level=high",
     "security:osv": "osv-scanner --lockfile=package-lock.json",


### PR DESCRIPTION
## Summary
Fixes #35 — every `git push` was hanging ~50 minutes because the `links` script globbed `'**/*.md'` with no exclusions, sending lychee through **2,097** markdown files under `node_modules/` (the repo owns **7**). Observed wedged on an expired TLS cert in `node_modules/yjs/README.md`'s links.

- `--exclude-path` for `node_modules`, `dist`, `build`, `coverage` (mirrors `lint:md`'s exclusions)
- New `.lycheeignore` excluding `localhost`/`127.0.0.1` dev-server URLs from the README so the check isn't permanently red

## Verification
- Before: pre-push hook hung 50+ min (killed manually)
- After: `npm run links` → `🔍 10 Total (in 1s) ✅ 8 OK 🚫 0 Errors 👻 2 Excluded`, exit 0
- This branch was pushed with the full pre-push hook active — completed in seconds

Closes #35