### PR TITLE
fix(editor): redesign shortcuts dialog and add missing key bindings

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -152,66 +152,187 @@ export default function Editor({ onContentChange }) {
               </button>
             </div>
             <div className="editor-docs-body">
-              <ul>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Z</kbd>: Undo
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Y</kbd> (or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> +{' '}
-                  <kbd>Z</kbd>): Redo
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>B</kbd>: Bold
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>I</kbd>: Italic
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>U</kbd>: Underline
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>K</kbd>: Insert or Edit Link
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>8</kbd>: Bullet List
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>7</kbd>: Numbered List
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Q</kbd>: Blockquote
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>1</kbd>: Heading 1
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>2</kbd>: Heading 2
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>3</kbd>: Heading 3
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>4</kbd>: Heading 4
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>5</kbd>: Heading 5
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>6</kbd>: Heading 6
-                </li>
-                <li>
-                  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd>: Paste as plain text
-                </li>
-                <li>
-                  <kbd>Esc</kbd>: Exit editor focus
-                </li>
-                <li>
-                  <kbd>←</kbd> / <kbd>→</kbd> (in toolbar): Move between toolbar buttons;{' '}
-                  <kbd>Home</kbd> / <kbd>End</kbd> jump to first/last
-                </li>
-              </ul>
-              <h3>Usage Tips</h3>
-              <p>Use the toolbar buttons or keyboard shortcuts to format your content.</p>
+              <p className="editor-docs-platform-note">
+                On macOS, use <kbd>Cmd</kbd> (⌘) wherever <kbd>Ctrl</kbd> is shown.
+              </p>
+              <div className="shortcuts-sections">
+                <section className="shortcuts-section">
+                  <h3>Text formatting</h3>
+                  <dl className="shortcuts-list">
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>B</kbd>
+                      </dt>
+                      <dd>Bold</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>I</kbd>
+                      </dt>
+                      <dd>Italic</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>U</kbd>
+                      </dt>
+                      <dd>Underline</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd>
+                      </dt>
+                      <dd>Strikethrough</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>E</kbd>
+                      </dt>
+                      <dd>Inline code</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>\</kbd>
+                      </dt>
+                      <dd>Clear formatting</dd>
+                    </div>
+                  </dl>
+                </section>
+
+                <section className="shortcuts-section">
+                  <h3>Headings</h3>
+                  <dl className="shortcuts-list">
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>1</kbd>–<kbd>6</kbd>
+                      </dt>
+                      <dd>Heading 1 through 6</dd>
+                    </div>
+                  </dl>
+                </section>
+
+                <section className="shortcuts-section">
+                  <h3>Blocks &amp; lists</h3>
+                  <dl className="shortcuts-list">
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>8</kbd>
+                      </dt>
+                      <dd>Bullet list</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>7</kbd>
+                      </dt>
+                      <dd>Numbered list</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Q</kbd>
+                      </dt>
+                      <dd>Blockquote</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd>
+                      </dt>
+                      <dd>Code block</dd>
+                    </div>
+                  </dl>
+                </section>
+
+                <section className="shortcuts-section">
+                  <h3>Insert</h3>
+                  <dl className="shortcuts-list">
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>K</kbd>
+                      </dt>
+                      <dd>Insert or edit link</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>M</kbd>
+                      </dt>
+                      <dd>Insert image</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
+                      </dt>
+                      <dd>Insert table</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>-</kbd>
+                      </dt>
+                      <dd>Horizontal rule</dd>
+                    </div>
+                  </dl>
+                </section>
+
+                <section className="shortcuts-section">
+                  <h3>Editing</h3>
+                  <dl className="shortcuts-list">
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Z</kbd>
+                      </dt>
+                      <dd>Undo</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Y</kbd> / <kbd>Ctrl</kbd> + <kbd>Shift</kbd> +{' '}
+                        <kbd>Z</kbd>
+                      </dt>
+                      <dd>Redo</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd>
+                      </dt>
+                      <dd>Paste as plain text</dd>
+                    </div>
+                  </dl>
+                </section>
+
+                <section className="shortcuts-section">
+                  <h3>Help &amp; navigation</h3>
+                  <dl className="shortcuts-list">
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Ctrl</kbd> + <kbd>D</kbd>
+                      </dt>
+                      <dd>Toggle this help dialog</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Esc</kbd>
+                      </dt>
+                      <dd>Close dialog / exit editor focus</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>←</kbd> / <kbd>→</kbd>
+                      </dt>
+                      <dd>Move between toolbar buttons</dd>
+                    </div>
+                    <div className="shortcut-row">
+                      <dt>
+                        <kbd>Home</kbd> / <kbd>End</kbd>
+                      </dt>
+                      <dd>First / last toolbar button</dd>
+                    </div>
+                  </dl>
+                </section>
+              </div>
+
+              <h3>Markdown auto-formatting</h3>
+              <p>
+                Type these and they convert as you go: <kbd>#</kbd>–<kbd>######</kbd> for headings,{' '}
+                <kbd>&gt;</kbd> for a blockquote, <kbd>-</kbd> or <kbd>*</kbd> for a bullet list,{' '}
+                <kbd>1.</kbd> for a numbered list, <kbd>**bold**</kbd>, <kbd>*italic*</kbd>, and{' '}
+                <kbd>[text](url)</kbd> for links.
+              </p>
             </div>
           </div>
         </div>

--- a/src/components/ToolbarPlugin.js
+++ b/src/components/ToolbarPlugin.js
@@ -442,6 +442,50 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
               editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined);
             }
             break;
+          case 'e':
+            // Ctrl/Cmd + E toggles inline code; + Shift toggles a code block
+            e.preventDefault();
+            if (e.shiftKey) {
+              toggleCodeBlock();
+            } else {
+              editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
+            }
+            break;
+          case 'x':
+            if (e.shiftKey) {
+              // Ctrl/Cmd + Shift + X toggles strikethrough
+              e.preventDefault();
+              editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
+            }
+            break;
+          case '\\':
+            // Ctrl/Cmd + \ clears formatting (Google Docs convention)
+            e.preventDefault();
+            clearFormatting();
+            break;
+          case 'm':
+            if (e.shiftKey) {
+              // Ctrl/Cmd + Shift + M opens the insert-image dialog
+              e.preventDefault();
+              setShowImageDialog(true);
+            }
+            break;
+          case 'l':
+            if (e.shiftKey) {
+              // Ctrl/Cmd + Shift + L opens the insert-table dialog
+              e.preventDefault();
+              setShowTableDialog(true);
+            }
+            break;
+          case '-':
+          case '_':
+            // Ctrl/Cmd + Shift + - inserts a horizontal rule (Shift+- is '_'
+            // on US layouts, so accept both keys)
+            if (e.shiftKey) {
+              e.preventDefault();
+              editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined);
+            }
+            break;
           default:
             break;
         }
@@ -482,7 +526,16 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [editor, setShowDocs, t, setHeading, openLinkDialog, toggleQuote]);
+  }, [
+    editor,
+    setShowDocs,
+    t,
+    setHeading,
+    openLinkDialog,
+    toggleQuote,
+    toggleCodeBlock,
+    clearFormatting,
+  ]);
 
   // Register Escape key to close link dialog
   useEffect(() => {

--- a/src/styles/Editor.css
+++ b/src/styles/Editor.css
@@ -159,20 +159,50 @@
 
 .editor-docs-body h3 {
   color: var(--primary-dark);
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
 }
 
-.editor-docs-body ul {
-  list-style: none;
-  padding-left: 0;
+.editor-docs-platform-note {
+  margin: 0 0 1rem;
+  color: var(--text-light);
+  font-size: 0.9em;
+}
+
+/* Responsive multi-column layout for the shortcut categories. Each section is
+   kept whole so a category never splits across columns. */
+.shortcuts-sections {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem 2rem;
+  margin-bottom: 1.25rem;
 }
 
-.editor-docs-body li {
-  margin-bottom: 0.75em;
-  display: flex;
-  align-items: center;
+.shortcuts-section {
+  min-width: 0;
+}
+
+/* Two-column key/description grid. `display: contents` on each row lets the
+   <dt> (keys) and <dd> (label) align to the parent grid's two tracks, so the
+   key combos and their descriptions never overlap regardless of length. */
+.shortcuts-list {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.4rem 1rem;
+  margin: 0;
+}
+
+.shortcut-row {
+  display: contents;
+}
+
+.shortcuts-list dt {
+  white-space: nowrap;
+}
+
+.shortcuts-list dd {
+  margin: 0;
+  align-self: center;
 }
 
 kbd {
@@ -278,7 +308,8 @@ kbd {
   cursor: not-allowed;
 }
 
-.editor-toolbar button[aria-disabled='true']:hover {
+.editor-toolbar button[aria-disabled='true']:hover,
+.editor-toolbar button[aria-disabled='true']:focus {
   background-color: var(--background);
   border-color: var(--border-color);
   color: var(--text-color);
@@ -437,6 +468,17 @@ kbd {
   justify-content: flex-end;
   gap: 8px;
   margin-top: 10px;
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .cancel-button,
+  .insert-button {
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: none;
+  }
 }
 
 .cancel-button,

--- a/src/tests/Editor.test.js
+++ b/src/tests/Editor.test.js
@@ -248,8 +248,10 @@ describe('Editor Component', () => {
     const showDocsButton = screen.getByTestId('show-docs-button');
     await user.click(showDocsButton);
 
-    expect(screen.getByText('Usage Tips')).toBeInTheDocument();
-    expect(screen.getByText(/Use the toolbar buttons or keyboard shortcuts/)).toBeInTheDocument();
+    expect(screen.getByText('Markdown auto-formatting')).toBeInTheDocument();
+    expect(screen.getByText('Strikethrough')).toBeInTheDocument();
+    expect(screen.getByText('Insert table')).toBeInTheDocument();
+    expect(screen.getByText('Toggle this help dialog')).toBeInTheDocument();
   });
 
   it('exports semantic <pre>/<code> without utility classes', () => {

--- a/src/tests/ToolbarPlugin.test.js
+++ b/src/tests/ToolbarPlugin.test.js
@@ -772,6 +772,65 @@ describe('ToolbarPlugin Component', () => {
     expect(mockEditor.update).toHaveBeenCalled();
   });
 
+  it('toggles strikethrough with the Ctrl+Shift+X keyboard shortcut', () => {
+    renderWithI18n(<ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} />);
+
+    fireEvent.keyDown(document, { key: 'X', ctrlKey: true, shiftKey: true });
+
+    expect(mockEditor.dispatchCommand).toHaveBeenCalledWith('format-text', 'strikethrough');
+  });
+
+  it('toggles inline code with the Ctrl+E keyboard shortcut', () => {
+    renderWithI18n(<ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} />);
+
+    fireEvent.keyDown(document, { key: 'e', ctrlKey: true });
+
+    expect(mockEditor.dispatchCommand).toHaveBeenCalledWith('format-text', 'code');
+  });
+
+  it('toggles a code block with the Ctrl+Shift+E keyboard shortcut', () => {
+    mockEditor.update.mockClear();
+    renderWithI18n(<ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} />);
+
+    fireEvent.keyDown(document, { key: 'E', ctrlKey: true, shiftKey: true });
+
+    expect(mockEditor.update).toHaveBeenCalled();
+  });
+
+  it('clears formatting with the Ctrl+\\ keyboard shortcut', () => {
+    mockEditor.update.mockClear();
+    renderWithI18n(<ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} />);
+
+    fireEvent.keyDown(document, { key: '\\', ctrlKey: true });
+
+    expect(mockEditor.update).toHaveBeenCalled();
+  });
+
+  it('inserts a horizontal rule with the Ctrl+Shift+- keyboard shortcut', () => {
+    mockEditor.dispatchCommand.mockClear();
+    renderWithI18n(<ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} />);
+
+    fireEvent.keyDown(document, { key: '_', ctrlKey: true, shiftKey: true });
+
+    expect(mockEditor.dispatchCommand).toHaveBeenCalledWith('insert-horizontal-rule', undefined);
+  });
+
+  it('opens the image dialog with the Ctrl+Shift+M keyboard shortcut', () => {
+    renderWithI18n(<ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} />);
+
+    fireEvent.keyDown(document, { key: 'M', ctrlKey: true, shiftKey: true });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('opens the table dialog with the Ctrl+Shift+L keyboard shortcut', () => {
+    renderWithI18n(<ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} />);
+
+    fireEvent.keyDown(document, { key: 'L', ctrlKey: true, shiftKey: true });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
   it('renders the horizontal rule button', () => {
     renderWithI18n(<ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} />);
 


### PR DESCRIPTION
## Summary

The editor's keyboard-shortcuts overlay had overlapping content and was missing shortcuts/documentation for newer toolbar features. This fixes the layout and rounds out the shortcut set.

### Layout fix
The old list rendered each item as `display: flex` with no wrapping, so long key combos overflowed their fixed-width grid column and visually overlapped neighboring items. The dialog is now built from semantic `<dl>` groups in a responsive, two-track grid (`max-content 1fr`) — keys and descriptions align in columns and never collide regardless of length. Categories flow in an `auto-fit` grid that reflows by viewport width.

### New keyboard shortcuts
Added bindings for toolbar features that previously had none, choosing combos that avoid browser-reserved chords (no Ctrl+Shift+I/J/C/T/R/N):

| Feature | Shortcut |
|---|---|
| Strikethrough | `Ctrl/Cmd+Shift+X` |
| Inline code | `Ctrl/Cmd+E` |
| Code block | `Ctrl/Cmd+Shift+E` |
| Clear formatting | `Ctrl/Cmd+\` |
| Insert image | `Ctrl/Cmd+Shift+M` |
| Insert table | `Ctrl/Cmd+Shift+L` |
| Horizontal rule | `Ctrl/Cmd+Shift+-` |

The HR handler accepts both `-` and `_` since Shift+`-` is `_` on US layouts. Bindings live in the existing document-level handler keyed on letters/chars (avoids the macOS Option-remap subtlety that the digit-based heading shortcuts already live with).

### Documentation
The dialog is reorganized into categories (Text formatting · Headings · Blocks & lists · Insert · Editing · Help & navigation), now documents the previously-undocumented `Ctrl/Cmd+D` (toggle help), adds a Markdown auto-formatting section, and notes the macOS Cmd substitution.

## Testing
- All 146 unit tests pass
- Updated two `Editor.test.js` assertions tied to the removed "Usage Tips" copy
- Added 7 `ToolbarPlugin.test.js` cases, one per new shortcut
- ESLint / Stylelint: 0 errors (only pre-existing warnings)

## Notes for reviewers
`Ctrl/Cmd+Shift+L` for table isn't strongly mnemonic — open to a different binding if preferred.

https://claude.ai/code/session_017WKiTs6ira4DqW1LeW18ZE