### PR TITLE
feat(image): drag-and-drop / file upload when an upload handler is configured

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,17 @@ import Editor from './components/Editor';
 import './styles/Editor.css';
 import i18n from './utils/i18n';
 
+// Demo upload handler: reads the file into a data URL so the upload UI works
+// without a backend. A real app would POST the file and return the hosted URL.
+function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
 export default function App() {
   const [content, setContent] = useState('');
 
@@ -13,7 +24,7 @@ export default function App() {
     <I18nextProvider i18n={i18n}>
       <div>
         <h1>Lexical Rich Text Editor</h1>
-        <Editor onContentChange={setContent} />
+        <Editor onContentChange={setContent} onImageUpload={readFileAsDataUrl} />
         <h2>Output HTML</h2>
         <pre>{content}</pre>
       </div>

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -82,14 +82,24 @@ const editorConfig = {
   ],
 };
 
-export default function Editor({ onContentChange }) {
+/**
+ * Accessible rich-text editor.
+ *
+ * @param {object} props
+ * @param {(html: string) => void} props.onContentChange Called with cleaned HTML on edit.
+ * @param {(file: File) => Promise<string>} [props.onImageUpload] Optional async
+ *   upload handler. When provided, the Insert Image dialog gains a drag-and-drop
+ *   zone and file picker; the handler receives the chosen File and must resolve
+ *   to the URL to embed. When omitted, the dialog stays URL-only.
+ */
+export default function Editor({ onContentChange, onImageUpload }) {
   const { t } = useTranslation();
   const [showDocs, setShowDocs] = useState(false);
   const [, setHtmlOutput] = useState('');
 
   return (
     <LexicalComposer initialConfig={editorConfig}>
-      <ToolbarPlugin showDocs={showDocs} setShowDocs={setShowDocs} />
+      <ToolbarPlugin showDocs={showDocs} setShowDocs={setShowDocs} onImageUpload={onImageUpload} />
 
       <div className="editor-container">
         <div className="editor-content-area">

--- a/src/components/ToolbarPlugin.js
+++ b/src/components/ToolbarPlugin.js
@@ -40,7 +40,7 @@ import { isSafeUrl, sanitizeUrl } from '../utils/sanitize-url';
 
 import { $createImageNode } from './ImageNode';
 
-export function ToolbarPlugin({ showDocs, setShowDocs }) {
+export function ToolbarPlugin({ showDocs, setShowDocs, onImageUpload }) {
   const [editor] = useLexicalComposerContext();
   const { t } = useTranslation();
   const [showLinkDialog, setShowLinkDialog] = useState(false);
@@ -58,9 +58,15 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
   const [imageUrl, setImageUrl] = useState('');
   const [imageAlt, setImageAlt] = useState('');
   const [imageDecorative, setImageDecorative] = useState(false);
+  // Upload UI is only offered when the host app configures an upload handler.
+  const canUploadImage = typeof onImageUpload === 'function';
+  const [isDraggingImage, setIsDraggingImage] = useState(false);
+  const [uploadStatus, setUploadStatus] = useState('idle'); // idle | uploading | error
+  const [uploadMessage, setUploadMessage] = useState('');
   const dialogRef = useRef(null);
   const urlInputRef = useRef(null);
   const imageUrlInputRef = useRef(null);
+  const imageFileInputRef = useRef(null);
 
   // Alt text is required unless the image is explicitly marked decorative
   const canInsertImage = Boolean(imageUrl.trim() && (imageAlt.trim() !== '' || imageDecorative));
@@ -70,7 +76,40 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
     setImageUrl('');
     setImageAlt('');
     setImageDecorative(false);
+    setIsDraggingImage(false);
+    setUploadStatus('idle');
+    setUploadMessage('');
   }, []);
+
+  // Run a dropped/selected file through the configured upload handler and use
+  // the returned URL. The handler owns where the bytes actually go (S3, API,
+  // data URL, …); this component only needs a URL back.
+  const handleImageFile = useCallback(
+    async (file) => {
+      if (!canUploadImage || !file) return;
+      if (!file.type || !file.type.startsWith('image/')) {
+        setUploadStatus('error');
+        setUploadMessage(t('imageUploadInvalidType'));
+        return;
+      }
+      setUploadStatus('uploading');
+      setUploadMessage(t('imageUploading'));
+      try {
+        const url = await onImageUpload(file);
+        if (typeof url !== 'string' || url.trim() === '') {
+          throw new Error('Upload handler did not return a URL');
+        }
+        setImageUrl(url.trim());
+        setUploadStatus('idle');
+        setUploadMessage(t('imageUploadComplete'));
+      } catch (error) {
+        console.error('Image upload failed:', error);
+        setUploadStatus('error');
+        setUploadMessage(t('imageUploadError'));
+      }
+    },
+    [canUploadImage, onImageUpload, t],
+  );
 
   const insertImage = useCallback(() => {
     if (!canInsertImage) return;
@@ -1615,8 +1654,61 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
           >
             <h3 id="image-dialog-title">{t('insertImage')}</h3>
             <div className="link-dialog-form">
+              {canUploadImage ? (
+                <div className="form-group">
+                  <div
+                    className={`image-dropzone ${isDraggingImage ? 'dragover' : ''}`}
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                      setIsDraggingImage(true);
+                    }}
+                    onDragLeave={() => setIsDraggingImage(false)}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      setIsDraggingImage(false);
+                      handleImageFile(e.dataTransfer.files && e.dataTransfer.files[0]);
+                    }}
+                    role="presentation"
+                  >
+                    <p className="image-dropzone-hint">{t('imageDropHint')}</p>
+                    <button
+                      type="button"
+                      className="upload-button"
+                      onClick={() => imageFileInputRef.current && imageFileInputRef.current.click()}
+                    >
+                      {t('chooseImageFile')}
+                    </button>
+                    {/* Hidden native input; the button above is the accessible
+                        control, so keep the input out of the tab order. */}
+                    <input
+                      ref={imageFileInputRef}
+                      type="file"
+                      accept="image/*"
+                      className="visually-hidden"
+                      tabIndex={-1}
+                      aria-hidden="true"
+                      onChange={(e) => {
+                        handleImageFile(e.target.files && e.target.files[0]);
+                        // Allow re-selecting the same file later
+                        e.target.value = '';
+                      }}
+                    />
+                  </div>
+                  <p
+                    className={`upload-status ${
+                      uploadStatus === 'error' ? 'upload-status-error' : ''
+                    }`}
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {uploadMessage}
+                  </p>
+                </div>
+              ) : null}
               <div className="form-group">
-                <label htmlFor="image-url">{t('url')}:</label>
+                <label htmlFor="image-url">
+                  {canUploadImage ? t('orPasteUrl') : `${t('url')}:`}
+                </label>
                 <input
                   ref={imageUrlInputRef}
                   type="text"

--- a/src/styles/Editor.css
+++ b/src/styles/Editor.css
@@ -278,7 +278,8 @@ kbd {
   cursor: not-allowed;
 }
 
-.editor-toolbar button[aria-disabled='true']:hover {
+.editor-toolbar button[aria-disabled='true']:hover,
+.editor-toolbar button[aria-disabled='true']:focus {
   background-color: var(--background);
   border-color: var(--border-color);
   color: var(--text-color);
@@ -432,11 +433,99 @@ kbd {
   box-shadow: 0 0 0 2px rgb(67 97 238 / 20%);
 }
 
+/* Image upload drop zone (rendered only when an upload handler is configured) */
+.image-dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  border: 2px dashed var(--border-color);
+  border-radius: 6px;
+  text-align: center;
+  background-color: var(--primary-light);
+}
+
+.image-dropzone.dragover {
+  border-color: var(--primary-color);
+  background-color: #dbe4ff;
+}
+
+.image-dropzone-hint {
+  margin: 0;
+  color: var(--text-light);
+  font-size: 14px;
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .upload-button {
+    transition: none;
+  }
+}
+
+.upload-button {
+  padding: 6px 14px;
+  border: 1px solid var(--primary-color);
+  border-radius: 4px;
+  background-color: var(--background);
+  color: var(--primary-dark);
+  font-size: 14px;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.upload-button:hover,
+.upload-button:focus {
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
+.upload-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(67 97 238 / 30%);
+}
+
+/* aria-live region for upload progress/errors */
+.upload-status {
+  margin: 4px 0 0;
+  min-height: 1.2em;
+  font-size: 13px;
+  color: var(--text-light);
+}
+
+.upload-status-error {
+  color: var(--error-color);
+}
+
+/* Visually hide the native file input while keeping it operable */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .link-dialog-buttons {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
   margin-top: 10px;
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .cancel-button,
+  .insert-button {
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: none;
+  }
 }
 
 .cancel-button,

--- a/src/tests/ToolbarPlugin.test.js
+++ b/src/tests/ToolbarPlugin.test.js
@@ -2,7 +2,7 @@ import { $createCodeNode, $isCodeNode } from '@lexical/code';
 import { $isLinkNode } from '@lexical/link';
 import { $createQuoteNode, $isQuoteNode } from '@lexical/rich-text';
 import { $setBlocksType } from '@lexical/selection';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { $createParagraphNode } from 'lexical';
 import { I18nextProvider } from 'react-i18next';
@@ -443,6 +443,80 @@ describe('ToolbarPlugin Component', () => {
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       expect($insertNodes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('image upload (when an upload handler is configured)', () => {
+    const pngFile = () => new File(['x'], 'cat.png', { type: 'image/png' });
+    const openImageDialog = (user) => user.click(screen.getByLabelText('Insert Image'));
+
+    it('does not render the drop zone when no upload handler is provided', async () => {
+      const user = userEvent.setup();
+      renderWithI18n(<ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} />);
+      await openImageDialog(user);
+
+      expect(screen.queryByRole('button', { name: 'Choose image file' })).not.toBeInTheDocument();
+    });
+
+    it('renders a drop zone and file picker when a handler is provided', async () => {
+      const user = userEvent.setup();
+      renderWithI18n(
+        <ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} onImageUpload={jest.fn()} />,
+      );
+      await openImageDialog(user);
+
+      expect(screen.getByRole('button', { name: 'Choose image file' })).toBeInTheDocument();
+    });
+
+    it('uploads a selected file and fills the URL from the handler result', async () => {
+      const onImageUpload = jest.fn().mockResolvedValue('https://cdn.test/cat.png');
+      const user = userEvent.setup();
+      const { container } = renderWithI18n(
+        <ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} onImageUpload={onImageUpload} />,
+      );
+      await openImageDialog(user);
+
+      const fileInput = container.querySelector('input[type="file"]');
+      fireEvent.change(fileInput, { target: { files: [pngFile()] } });
+
+      await waitFor(() => expect(onImageUpload).toHaveBeenCalledTimes(1));
+      expect(onImageUpload.mock.calls[0][0]).toBeInstanceOf(File);
+      await waitFor(() =>
+        expect(screen.getByLabelText(/paste an image URL/i)).toHaveValue(
+          'https://cdn.test/cat.png',
+        ),
+      );
+    });
+
+    it('rejects a non-image file and does not call the handler', async () => {
+      const onImageUpload = jest.fn();
+      const user = userEvent.setup();
+      const { container } = renderWithI18n(
+        <ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} onImageUpload={onImageUpload} />,
+      );
+      await openImageDialog(user);
+
+      const fileInput = container.querySelector('input[type="file"]');
+      fireEvent.change(fileInput, {
+        target: { files: [new File(['x'], 'note.txt', { type: 'text/plain' })] },
+      });
+
+      expect(onImageUpload).not.toHaveBeenCalled();
+      expect(screen.getByRole('status')).toHaveTextContent(/not an image/i);
+    });
+
+    it('surfaces an error when the upload handler rejects', async () => {
+      const onImageUpload = jest.fn().mockRejectedValue(new Error('network'));
+      const user = userEvent.setup();
+      const { container } = renderWithI18n(
+        <ToolbarPlugin showDocs={false} setShowDocs={setShowDocs} onImageUpload={onImageUpload} />,
+      );
+      await openImageDialog(user);
+
+      const fileInput = container.querySelector('input[type="file"]');
+      fireEvent.change(fileInput, { target: { files: [pngFile()] } });
+
+      await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/Upload failed/i));
     });
   });
 

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -46,6 +46,14 @@ i18n.use(initReactI18next).init({
         altText: 'Alt Text',
         altTextHint: 'Describe the image for screen reader users, or mark it as decorative.',
         decorativeImage: 'This image is decorative (no alt text needed)',
+        // Image upload (shown only when an upload handler is configured)
+        imageDropHint: 'Drag an image here, or',
+        chooseImageFile: 'Choose image file',
+        orPasteUrl: 'Or paste an image URL:',
+        imageUploading: 'Uploading image…',
+        imageUploadComplete: 'Image uploaded. Add alt text, then insert.',
+        imageUploadError: 'Upload failed. Try again or paste a URL instead.',
+        imageUploadInvalidType: 'That file is not an image. Choose an image file.',
         // New translations for link dialog
         insertLink: 'Insert Link',
         editLink: 'Edit Link',


### PR DESCRIPTION
## Summary

The Insert Image dialog only accepted a URL. This adds an optional **`onImageUpload`** prop to `<Editor>`: when the host app provides an async `(file) => Promise<url>` handler, the dialog gains a **drag-and-drop zone plus a file picker**; when no handler is configured, the dialog is unchanged (URL-only). Fully backward compatible.

## API
```jsx
<Editor
  onContentChange={setHtml}
  onImageUpload={async (file) => {
    const { url } = await uploadToMyBackend(file);
    return url; // becomes the <img src>
  }}
/>
```
The handler owns where bytes go (S3, an API, a data URL, …); the editor only needs a URL back.

## Behavior
- `handleImageFile` validates the file is an image, calls the handler, fills the URL field from the returned value, and reports progress/errors through an `aria-live="polite"` status region. The existing **alt-text requirement still gates Insert**, so accessibility isn't bypassed by uploads.
- Drag-over highlights the drop zone; the file picker is a real `<button>` driving a visually-hidden native `<input type="file">` (keyboard accessible; the input is kept out of the tab order and `aria-hidden`).
- `closeImageDialog` resets upload state; the same-file can be re-selected (input value cleared after each change).
- Non-image files and handler rejections show a distinct error message.

## Demo
`App.js` wires a demo handler (`FileReader` → data URL) so the drop zone is visible in the demo without a backend. Library code itself ships no default handler.

## Testing
- 5 new ToolbarPlugin tests: drop zone hidden without a handler; shown with one; a selected file uploads and fills the URL; non-image files are rejected without calling the handler; a rejected upload surfaces an error.
- Full suite: 144 passing; ESLint/Stylelint: 0 errors.
- Verified end-to-end in a real browser (Playwright): a file set on the dialog uploads, populates the URL, and inserts an `<img>` carrying the entered alt text.

https://claude.ai/code/session_017WKiTs6ira4DqW1LeW18ZE