### PR TITLE
feat(toolbar): add shortcut hints to tooltips for the new bindings

### DIFF
--- a/src/components/ToolbarPlugin.js
+++ b/src/components/ToolbarPlugin.js
@@ -1018,7 +1018,7 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
         <button
           onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough')}
           aria-label={t('strikethrough')}
-          {...getTriggerProps('strikethrough', t('strikethrough'))}
+          {...getTriggerProps('strikethrough', `${t('strikethrough')} (${modKey}+Shift+X)`)}
           className={isStrikethrough ? 'active' : ''}
           aria-pressed={isStrikethrough}
         >
@@ -1057,7 +1057,7 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
         <button
           onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code')}
           aria-label={t('inlineCode')}
-          {...getTriggerProps('inlineCode', t('inlineCode'))}
+          {...getTriggerProps('inlineCode', `${t('inlineCode')} (${modKey}+E)`)}
           className={isInlineCode ? 'active' : ''}
           aria-pressed={isInlineCode}
         >
@@ -1089,7 +1089,7 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
         <button
           onClick={toggleCodeBlock}
           aria-label={t('codeBlock')}
-          {...getTriggerProps('codeBlock', t('codeBlock'))}
+          {...getTriggerProps('codeBlock', `${t('codeBlock')} (${modKey}+Shift+E)`)}
           className={`code-block-button ${isCodeBlockActive ? 'active' : ''}`}
           aria-pressed={isCodeBlockActive}
         >
@@ -1122,7 +1122,7 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
         <button
           onClick={clearFormatting}
           aria-label={t('clearFormatting')}
-          {...getTriggerProps('clearFormatting', t('clearFormatting'))}
+          {...getTriggerProps('clearFormatting', `${t('clearFormatting')} (${modKey}+\\)`)}
           className="clear-formatting-button"
         >
           <svg
@@ -1276,7 +1276,7 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
           className="image-button"
           onClick={() => setShowImageDialog(true)}
           aria-label={t('insertImage')}
-          {...getTriggerProps('insertImage', t('insertImage'))}
+          {...getTriggerProps('insertImage', `${t('insertImage')} (${modKey}+Shift+M)`)}
         >
           <svg
             className="icon-image"
@@ -1302,7 +1302,7 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
           className="table-button"
           onClick={() => setShowTableDialog(true)}
           aria-label={t('insertTable')}
-          {...getTriggerProps('insertTable', t('insertTable'))}
+          {...getTriggerProps('insertTable', `${t('insertTable')} (${modKey}+Shift+L)`)}
         >
           <svg
             className="icon-table"
@@ -1428,7 +1428,10 @@ export function ToolbarPlugin({ showDocs, setShowDocs }) {
           type="button"
           onClick={() => editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined)}
           aria-label={t('insertHorizontalRule')}
-          {...getTriggerProps('insertHorizontalRule', t('insertHorizontalRule'))}
+          {...getTriggerProps(
+            'insertHorizontalRule',
+            `${t('insertHorizontalRule')} (${modKey}+Shift+-)`,
+          )}
           className="horizontal-rule-button"
         >
           <svg


### PR DESCRIPTION
## Summary (queued follow-up — draft)

Fills in the shortcut hints that the tooltips PR (#58) intentionally left as label-only, now that those keyboard bindings exist in the shortcuts PR (#55):

| Button | Tooltip hint |
|---|---|
| Strikethrough | `Ctrl/Cmd+Shift+X` |
| Inline code | `Ctrl/Cmd+E` |
| Code block | `Ctrl/Cmd+Shift+E` |
| Clear formatting | `Ctrl/Cmd+\` |
| Insert image | `Ctrl/Cmd+Shift+M` |
| Insert table | `Ctrl/Cmd+Shift+L` |
| Horizontal rule | `Ctrl/Cmd+Shift+-` |

Uses the same platform-aware modifier (Cmd on macOS, Ctrl elsewhere) as the rest of the tooltips.

## ⚠️ Merge order
**Draft on purpose.** This must merge only **after both #58 (tooltips) and #55 (shortcuts)** are on `develop`, so the advertised shortcuts actually work.

- Base is set to `feature/toolbar-tooltips` so this PR's diff shows only the 7-line hint change. When #58 merges and its branch is deleted, GitHub will auto-retarget this PR to `develop`.
- It does not import anything from #55 (the hints are display strings), so there's no code dependency — only the semantic one above.

Ready to mark "Ready for review" once #58 and #55 land.

https://claude.ai/code/session_017WKiTs6ira4DqW1LeW18ZE