### PR TITLE
fix(link): stop duplicating selected text when inserting a link

### DIFF
--- a/src/components/ToolbarPlugin.js
+++ b/src/components/ToolbarPlugin.js
@@ -20,10 +20,12 @@ import { $setBlocksType } from '@lexical/selection';
 import { INSERT_TABLE_COMMAND } from '@lexical/table';
 import {
   $createParagraphNode,
+  $createRangeSelection,
   $getSelection,
   $insertNodes,
   $isRangeSelection,
   $isTextNode,
+  $setSelection,
   CAN_REDO_COMMAND,
   CAN_UNDO_COMMAND,
   COMMAND_PRIORITY_HIGH,
@@ -72,6 +74,11 @@ export function ToolbarPlugin({ showDocs, setShowDocs, onImageUpload }) {
   const [uploadMessage, setUploadMessage] = useState('');
   const dialogRef = useRef(null);
   const urlInputRef = useRef(null);
+  // The editor selection captured when the link dialog opens. The dialog steals
+  // DOM focus and re-focusing the editor on Insert collapses the live selection,
+  // so we restore this snapshot before applying the link — otherwise a selected
+  // word gets re-inserted (e.g. "lexical" → "lexicallexical").
+  const savedLinkSelectionRef = useRef(null);
   const imageUrlInputRef = useRef(null);
   const imageFileInputRef = useRef(null);
 
@@ -313,9 +320,20 @@ export function ToolbarPlugin({ showDocs, setShowDocs, onImageUpload }) {
   // Open the link dialog, pre-filled from an existing link when the
   // cursor/selection is inside one (edit mode), or from the selected text
   const openLinkDialog = useCallback(() => {
+    savedLinkSelectionRef.current = null;
     editor.getEditorState().read(() => {
       const selection = $getSelection();
       if ($isRangeSelection(selection)) {
+        // Snapshot the live selection so Insert can restore it after the dialog
+        // closes (see savedLinkSelectionRef).
+        savedLinkSelectionRef.current = {
+          anchorKey: selection.anchor.key,
+          anchorOffset: selection.anchor.offset,
+          anchorType: selection.anchor.type,
+          focusKey: selection.focus.key,
+          focusOffset: selection.focus.offset,
+          focusType: selection.focus.type,
+        };
         const linkNode = findLinkNode(selection.anchor.getNode());
         if (linkNode) {
           // Editing an existing link: pre-fill its URL and text
@@ -1649,6 +1667,27 @@ export function ToolbarPlugin({ showDocs, setShowDocs, onImageUpload }) {
                       setTimeout(() => {
                         editor.focus();
                         editor.update(() => {
+                          // Restore the selection captured when the dialog opened;
+                          // re-focusing the editor collapses the live one.
+                          const saved = savedLinkSelectionRef.current;
+                          if (saved) {
+                            try {
+                              const restored = $createRangeSelection();
+                              restored.anchor.set(
+                                saved.anchorKey,
+                                saved.anchorOffset,
+                                saved.anchorType,
+                              );
+                              restored.focus.set(
+                                saved.focusKey,
+                                saved.focusOffset,
+                                saved.focusType,
+                              );
+                              $setSelection(restored);
+                            } catch {
+                              // Stale node keys — fall back to the live selection
+                            }
+                          }
                           const selection = $getSelection();
                           if ($isRangeSelection(selection)) {
                             const existingLink = findLinkNode(selection.anchor.getNode());
@@ -1681,6 +1720,7 @@ export function ToolbarPlugin({ showDocs, setShowDocs, onImageUpload }) {
                             }
                           }
                         });
+                        savedLinkSelectionRef.current = null;
                         setLinkUrl('');
                         setLinkText('');
                       }, 50);

--- a/src/tests/ToolbarPlugin.test.js
+++ b/src/tests/ToolbarPlugin.test.js
@@ -63,6 +63,11 @@ jest.mock('lexical', () => {
   return {
     $getSelection: jest.fn(() => mockSelection),
     $insertNodes: jest.fn(),
+    $createRangeSelection: jest.fn(() => ({
+      anchor: { set: jest.fn() },
+      focus: { set: jest.fn() },
+    })),
+    $setSelection: jest.fn(),
     $isRangeSelection: jest.fn(() => true),
     $isTextNode: jest.fn(() => true),
     $createParagraphNode: jest.fn(() => ({})),


### PR DESCRIPTION
## Summary

Linking a **selected** word duplicated its text — selecting "lexical" and inserting a link produced `lexicallexical` (the second copy being the link). This is a **pre-existing bug** (reproduces on the pre-session base commit `bf87393`), not introduced by recent work; it stayed hidden because the Playwright e2e job is billing-locked in CI and never actually ran.

## Root cause

The Insert handler closes the dialog and re-focuses the editor on a 50ms timeout. Re-focusing **collapses the live selection to a caret**. Because the link-text field is pre-filled from the selection, the `linkText && selection.isCollapsed()` branch then *re-inserted* the text instead of linking the existing selection.

## Fix

- Snapshot the editor selection (anchor/focus `key`, `offset`, `type`) when the dialog **opens**.
- Restore it via `$createRangeSelection` / `$setSelection` at the start of the Insert `update()`, so the original range is linked rather than a collapsed caret.
- Snapshot is reset on open and cleared after insert; restore is wrapped in try/catch to fall back to the live selection if node keys are stale.

Scope is limited to selection handling — the three insert branches (edit-in-place / typed-text-at-caret / wrap-selection) are unchanged.

## Testing
- **E2E: 12/12 pass** (was 11/1) — the `inserts a link through the accessible dialog` test now passes; verified it still failed on `bf87393` before this change.
- **Unit: 158/158 pass**, including the existing `edits an existing link in place without duplicating its text` guard. Added `$createRangeSelection`/`$setSelection` to the jest lexical mock.
- Build + Prettier clean.

> Note: GitHub's CI checks will show red (account billing lock — every job fails in ~2s without running). The gate above was reproduced locally.

https://claude.ai/code/session_017WKiTs6ira4DqW1LeW18ZE