### PR TITLE
feat(editor): add outputFormat option (HTML or Markdown)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,13 +19,41 @@ function readFileAsDataUrl(file) {
 
 export default function App() {
   const [content, setContent] = useState('');
+  const [outputFormat, setOutputFormat] = useState('html');
 
   return (
     <I18nextProvider i18n={i18n}>
       <div>
         <h1>Lexical Rich Text Editor</h1>
-        <Editor onContentChange={setContent} onImageUpload={readFileAsDataUrl} />
-        <h2>Output HTML</h2>
+        <fieldset className="output-format-control">
+          <legend>Output format</legend>
+          <label>
+            <input
+              type="radio"
+              name="output-format"
+              value="html"
+              checked={outputFormat === 'html'}
+              onChange={(e) => setOutputFormat(e.target.value)}
+            />{' '}
+            HTML
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="output-format"
+              value="markdown"
+              checked={outputFormat === 'markdown'}
+              onChange={(e) => setOutputFormat(e.target.value)}
+            />{' '}
+            Markdown
+          </label>
+        </fieldset>
+        <Editor
+          onContentChange={setContent}
+          outputFormat={outputFormat}
+          onImageUpload={readFileAsDataUrl}
+        />
+        <h2>Output ({outputFormat === 'markdown' ? 'Markdown' : 'HTML'})</h2>
         <pre>{content}</pre>
       </div>
     </I18nextProvider>

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -3,7 +3,9 @@ import { CodeHighlightNode, CodeNode } from '@lexical/code';
 import { $generateHtmlFromNodes } from '@lexical/html';
 import { LinkNode } from '@lexical/link';
 import { ListItemNode, ListNode } from '@lexical/list';
+import { $convertToMarkdownString } from '@lexical/markdown';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
@@ -17,7 +19,7 @@ import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { TablePlugin } from '@lexical/react/LexicalTablePlugin';
 import { HeadingNode, QuoteNode } from '@lexical/rich-text';
 import { TableCellNode, TableNode, TableRowNode } from '@lexical/table';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { EDITOR_TRANSFORMERS } from '../utils/markdown-transformers';
@@ -86,16 +88,78 @@ const editorConfig = {
 };
 
 /**
+ * Serialize the current editor state to the requested format. Must be called
+ * inside an editorState.read()/editor.read() so the Lexical $ helpers have an
+ * active state.
+ *
+ * @param {import('lexical').LexicalEditor} editor
+ * @param {'html' | 'markdown'} format
+ * @returns {string}
+ */
+function serializeContent(editor, format) {
+  if (format === 'markdown') {
+    // Curated transformer set; nodes without a Markdown form (tables, images,
+    // horizontal rules, code blocks) are omitted.
+    return $convertToMarkdownString(EDITOR_TRANSFORMERS);
+  }
+
+  // Generate HTML with default export (no custom transformer), then strip the
+  // theme's utility classes and Lexical's table sizing markup.
+  return (
+    $generateHtmlFromNodes(editor)
+      .replace(/class="[^"]*"/g, '') // Remove all class attributes
+      // List longer tags before their prefixes (pre before p) so the
+      // alternation doesn't rewrite <pre> as <p>.
+      .replace(/<(h[1-6]|pre|p|ul|ol|li|code|hr)([^>]*)>/g, '<$1>') // Clean heading, paragraph, list, code, and hr tags
+      .replace(/<a([^>]*)(class="[^"]*")([^>]*)>/g, '<a$1$3>') // Clean link tags
+      .replace(/<colgroup[^>]*>[\s\S]*?<\/colgroup>/g, '') // Drop Lexical's <colgroup>/<col> sizing markup
+      .replace(/<(table|thead|tbody|tr)([^>]*)>/g, '<$1>') // Clean table structure tags
+      .replace(/(<(?:td|th)\b[^>]*?)\s+style="[^"]*"/g, '$1') // Strip inline cell styles at any attribute position
+      .replace(/(<(?:td|th)\b[^>]*?)\s+>/g, '$1>') // Tidy trailing whitespace left by attribute stripping
+      // Header cells are all column headers (header row only), so scope="col".
+      // The (?![a-z]) guard keeps this from matching <thead>.
+      .replace(/<th(?![a-z])(?![^>]*\bscope=)([^>]*)>/g, '<th scope="col"$1>')
+  ); // Ensure header cells carry scope
+}
+
+/**
+ * Re-serialize and emit the current content when the output format changes, so
+ * consumers see the new format immediately instead of only after the next edit.
+ */
+function OutputFormatSync({ outputFormat, onContentChange }) {
+  const [editor] = useLexicalComposerContext();
+  const isInitialRun = useRef(true);
+  useEffect(() => {
+    // Skip the mount run — OnChangePlugin already emits the initial content.
+    // Only re-emit when the format actually changes afterward.
+    if (isInitialRun.current) {
+      isInitialRun.current = false;
+      return;
+    }
+    editor.getEditorState().read(() => {
+      onContentChange(serializeContent(editor, outputFormat));
+    });
+  }, [editor, outputFormat, onContentChange]);
+  return null;
+}
+
+/**
  * Accessible rich-text editor.
  *
  * @param {object} props
- * @param {(html: string) => void} props.onContentChange Called with cleaned HTML on edit.
+ * @param {(content: string) => void} props.onContentChange Called on edit with the
+ *   serialized content, in the format selected by `outputFormat`.
+ * @param {'html' | 'markdown'} [props.outputFormat] Format passed to
+ *   `onContentChange`: cleaned HTML (default) or Markdown. Markdown covers
+ *   headings, lists, blockquotes, links, and bold/italic/strikethrough; nodes
+ *   without a Markdown representation (tables, images, horizontal rules, code
+ *   blocks) are omitted from Markdown output.
  * @param {(file: File) => Promise<string>} [props.onImageUpload] Optional async
  *   upload handler. When provided, the Insert Image dialog gains a drag-and-drop
  *   zone and file picker; the handler receives the chosen File and must resolve
  *   to the URL to embed. When omitted, the dialog stays URL-only.
  */
-export default function Editor({ onContentChange, onImageUpload }) {
+export default function Editor({ onContentChange, outputFormat = 'html', onImageUpload }) {
   const { t } = useTranslation();
   const [showDocs, setShowDocs] = useState(false);
   const [, setHtmlOutput] = useState('');
@@ -123,29 +187,13 @@ export default function Editor({ onContentChange, onImageUpload }) {
           <OnChangePlugin
             onChange={(editorState, editor) => {
               editorState.read(() => {
-                // Generate HTML with default export (no custom transformer)
-                const htmlString = $generateHtmlFromNodes(editor);
-
-                // Use a simple regex to clean up the utility classes
-                const cleanHtml = htmlString
-                  .replace(/class="[^"]*"/g, '') // Remove all class attributes
-                  // List longer tags before their prefixes (pre before p) so the
-                  // alternation doesn't rewrite <pre> as <p>.
-                  .replace(/<(h[1-6]|pre|p|ul|ol|li|code|hr)([^>]*)>/g, '<$1>') // Clean heading, paragraph, list, code, and hr tags
-                  .replace(/<a([^>]*)(class="[^"]*")([^>]*)>/g, '<a$1$3>') // Clean link tags
-                  .replace(/<colgroup[^>]*>[\s\S]*?<\/colgroup>/g, '') // Drop Lexical's <colgroup>/<col> sizing markup
-                  .replace(/<(table|thead|tbody|tr)([^>]*)>/g, '<$1>') // Clean table structure tags
-                  .replace(/(<(?:td|th)\b[^>]*?)\s+style="[^"]*"/g, '$1') // Strip inline cell styles at any attribute position
-                  .replace(/(<(?:td|th)\b[^>]*?)\s+>/g, '$1>') // Tidy trailing whitespace left by attribute stripping
-                  // Header cells are all column headers (header row only), so scope="col".
-                  // The (?![a-z]) guard keeps this from matching <thead>.
-                  .replace(/<th(?![a-z])(?![^>]*\bscope=)([^>]*)>/g, '<th scope="col"$1>'); // Ensure header cells carry scope
-
-                setHtmlOutput(cleanHtml);
-                onContentChange(cleanHtml);
+                const serialized = serializeContent(editor, outputFormat);
+                setHtmlOutput(serialized);
+                onContentChange(serialized);
               });
             }}
           />
+          <OutputFormatSync outputFormat={outputFormat} onContentChange={onContentChange} />
         </div>
         <HeadingOutlinePlugin />
         <WordCountPlugin />

--- a/src/styles/Editor.css
+++ b/src/styles/Editor.css
@@ -24,6 +24,22 @@
   background-color: var(--background);
 }
 
+/* Demo output-format selector */
+.output-format-control {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin: 0 0 1rem;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.output-format-control legend {
+  font-weight: 600;
+  padding: 0 4px;
+}
+
 .editor-content-area {
   border: 1px solid var(--border-color);
   background-color: var(--background);
@@ -662,6 +678,17 @@ kbd {
   justify-content: flex-end;
   gap: 8px;
   margin-top: 10px;
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .cancel-button,
+  .insert-button {
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: none;
+  }
 }
 
 @media screen and (prefers-reduced-motion: reduce) {

--- a/src/tests/Editor.test.js
+++ b/src/tests/Editor.test.js
@@ -37,7 +37,13 @@ jest.mock('@lexical/link', () => ({
 
 // Mock the Lexical components and plugins
 jest.mock('@lexical/react/LexicalComposerContext', () => ({
-  useLexicalComposerContext: jest.fn(() => [{ update: jest.fn() }]),
+  useLexicalComposerContext: jest.fn(() => [
+    { update: jest.fn(), getEditorState: () => ({ read: (cb) => cb() }) },
+  ]),
+}));
+
+jest.mock('@lexical/markdown', () => ({
+  $convertToMarkdownString: jest.fn(() => '# Markdown output'),
 }));
 
 jest.mock('@lexical/react/LexicalComposer', () => ({
@@ -177,6 +183,36 @@ describe('Editor Component', () => {
     mockOnChangeCapture.onChange({ read: (cb) => cb() }, {});
 
     expect(mockOnContentChange).toHaveBeenCalledWith('<p>Intro</p><hr><p>End</p>');
+  });
+
+  it('emits Markdown when outputFormat is "markdown"', () => {
+    const { $convertToMarkdownString } = require('@lexical/markdown');
+    const { $generateHtmlFromNodes } = require('@lexical/html');
+    $convertToMarkdownString.mockClear();
+    $generateHtmlFromNodes.mockClear();
+    const mockOnContentChange = jest.fn();
+
+    renderWithI18n(<Editor onContentChange={mockOnContentChange} outputFormat="markdown" />);
+
+    // Both the on-edit path and the format-change sync use the Markdown serializer
+    mockOnChangeCapture.onChange({ read: (cb) => cb() }, {});
+
+    expect($convertToMarkdownString).toHaveBeenCalled();
+    expect($generateHtmlFromNodes).not.toHaveBeenCalled();
+    expect(mockOnContentChange).toHaveBeenCalledWith('# Markdown output');
+  });
+
+  it('emits HTML by default (outputFormat omitted)', () => {
+    const { $convertToMarkdownString } = require('@lexical/markdown');
+    $convertToMarkdownString.mockClear();
+    const mockOnContentChange = jest.fn();
+
+    renderWithI18n(<Editor onContentChange={mockOnContentChange} />);
+    mockOnChangeCapture.onChange({ read: (cb) => cb() }, {});
+
+    expect($convertToMarkdownString).not.toHaveBeenCalled();
+    // Default HTML mock output, cleaned of classes
+    expect(mockOnContentChange).toHaveBeenCalledWith('<p>Test HTML Output</p>');
   });
 
   it('exports clean, semantic table HTML with scoped header cells', () => {


### PR DESCRIPTION
## Summary

Adds an **`outputFormat`** configuration prop to `<Editor>` so consumers choose what `onContentChange` receives.

```jsx
<Editor onContentChange={setContent} outputFormat="markdown" /> // 'html' (default) | 'markdown'
```

- **`html`** (default) — unchanged cleaned-HTML export path. Fully backward compatible.
- **`markdown`** — serializes via `$convertToMarkdownString` with the curated transformer set: headings, lists, blockquotes, links, and bold/italic/strikethrough. Nodes without a Markdown representation (tables, images, horizontal rules, code blocks) are omitted — documented in the prop's JSDoc.

## Implementation
- Extracted `serializeContent(editor, format)` shared by the change handler.
- Added an `OutputFormatSync` plugin that re-emits the current content when the format **changes** (it skips the initial mount, since `OnChangePlugin` already emits there), so a consumer toggling the format sees the new output immediately rather than only after the next edit.
- Demo (`App.js`) gains an accessible HTML/Markdown radio `fieldset` and labels the output panel with the active format.

## Testing
- New unit tests: emits Markdown when `outputFormat="markdown"` (and does **not** call the HTML exporter), emits HTML by default. Existing HTML/`<hr>`/table export tests still pass. **160/160 unit tests pass.**
- Verified in a real browser (Playwright): toggling the selector switches the output panel between `<h1>…</h1>` and `# Title`, live, without re-editing.
- ESLint / Stylelint / Prettier: 0 errors.

> CI badges will show red (account billing lock — jobs fail in ~2s without running); gate reproduced locally.

https://claude.ai/code/session_017WKiTs6ira4DqW1LeW18ZE