### PR TITLE
Release v1.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,7 @@ This project follows **Git Flow**. You MUST adhere to this branching strategy:
 - Follow i18n patterns using react-i18next's useTranslation hook
 - Always provide alt text for images and proper ARIA attributes
 - Run ESLint with jsx-a11y plugin to catch accessibility issues
+
+## Reviewing PRs
+
+Whenever I ask to review a PR (pull request), use the `pr-review` skill.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventably/lexic-a11y",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventably/lexic-a11y",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@lexical/code": "0.12.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eventably/lexic-a11y",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A fully featured, accessible, and internationalized rich text editor built with React and Lexical",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## Release v1.0.1

Patch release. Documentation/tooling only — no runtime or API changes.

### What's changed
- **docs(claude):** instruct use of the `pr-review` skill when reviewing PRs (`CLAUDE.md`).
- **chore:** resync `develop` with `main` after the v1.0.0 release (the post-release back-merge that brings `main`'s release commits into `develop`), and bump version to `1.0.1`.

### Breaking changes
None.

### Notes
The published package contents are unchanged from v1.0.0 — this release exists to ship the doc update and realign the Git Flow branches.

**Compare:** https://github.com/eventably/lexic-a11y/compare/main...develop