### PR TITLE
chore: align main with @afixt package scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ In your React application, import the main Editor component:
 
 ```javascript
 import React, { useState } from 'react';
-import Editor from '@eventably/lexic-a11y';
-import '@eventably/lexic-a11y/dist/styles.css'; // Import the styles
+import Editor from '@afixt/lexic-a11y';
+import '@afixt/lexic-a11y/dist/styles.css'; // Import the styles
 
 export default function App() {
   const [content, setContent] = useState('');
@@ -141,7 +141,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { I18nextProvider } from 'react-i18next';
-import i18n from '@eventably/lexic-a11y/dist/i18n';
+import i18n from '@afixt/lexic-a11y/dist/i18n';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@eventably/lexic-a11y",
+  "name": "@afixt/lexic-a11y",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@eventably/lexic-a11y",
+      "name": "@afixt/lexic-a11y",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@eventably/lexic-a11y",
+  "name": "@afixt/lexic-a11y",
   "version": "1.0.1",
   "description": "A fully featured, accessible, and internationalized rich text editor built with React and Lexical",
   "main": "dist/index.js",


### PR DESCRIPTION
Brings the `@afixt` package rename onto `main` so the branch matches what's published to npm.

### Why
v1.0.1 was published to npm as **`@afixt/lexic-a11y`** (public), because the original `@eventably` scope can't publish privately without a paid plan (npm `E402`). The repo also moved to the `AFixt` GitHub org. The rename landed on `develop` but `main` still references `@eventably`, leaving the branches inconsistent with the published artifact.

### What's changed
- `chore(release): publish under @afixt scope` (`8d3aecf`) — renames the package in `package.json`, `package-lock.json`, and README install snippets from `@eventably/lexic-a11y` to `@afixt/lexic-a11y`.

### Notes
- No runtime/API changes; no version bump.
- The existing `v1.0.1` tag is left untouched (it points at the already-released commit, which predates this rename).

**Compare:** https://github.com/AFixt/lexic-a11y/compare/main...develop