### PR TITLE
fix(ci): authenticate npm ci for private @afixt deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,6 @@ jobs:
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Debug npm auth (temporary)
-        run: |
-          echo "Token length: ${#NODE_AUTH_TOKEN}"
-          echo "whoami:"; npm whoami || echo "whoami FAILED (token invalid/empty)"
-          echo "private dep view:"; npm view @afixt/test-utils version || echo "view FAILED (no read access)"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Install dependencies
         run: npm ci
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Debug npm auth (temporary)
+        run: |
+          echo "Token length: ${#NODE_AUTH_TOKEN}"
+          echo "whoami:"; npm whoami || echo "whoami FAILED (token invalid/empty)"
+          echo "private dep view:"; npm view @afixt/test-utils version || echo "view FAILED (no read access)"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Install dependencies
         run: npm ci
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Run ESLint
         run: npm run lint --if-present
@@ -59,9 +62,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check for TypeScript config
         id: check-ts
@@ -87,9 +93,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check for test script
         id: check-tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,9 +22,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -71,11 +71,14 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         if: steps.detect.outputs.type == 'node'
         run: npm ci --ignore-scripts
         continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Run lint check
         if: steps.detect.outputs.type == 'node'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,9 +41,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Run npm audit
         run: npm audit --audit-level=high
@@ -90,9 +93,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: OWASP Dependency Check
         uses: dependency-check/Dependency-Check_Action@main
@@ -131,9 +137,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install license-checker
         run: npm install -g license-checker


### PR DESCRIPTION
## Problem
CI has been failing on every job that runs `npm ci` (Lint, Tests, TypeScript, Playwright, NPM Audit). Root cause: the dev toolchain pulls in **private** `@afixt`-scoped packages transitively via the `@afixt/a11y-assert` devDependency:

```
@afixt/lexic-a11y → (dev) @afixt/a11y-assert → afixt-engine → afixt-tests → fix-utils → @afixt/test-utils
```

These packages are published but **private**, so unauthenticated requests get `404`. The repo already has an `NPM_TOKEN` secret, but **no workflow wired it into npm** — every `setup-node` lacked `registry-url` and every install step lacked `NODE_AUTH_TOKEN`, so `npm ci` ran anonymously and 404'd. (It only surfaced recently because CI hadn't actually executed before.)

## Fix
Apply the canonical `actions/setup-node` auth pattern to all 8 `npm ci` steps across the four workflows:
- `registry-url: "https://registry.npmjs.org"` on each `setup-node` (makes it write an `.npmrc` with the `_authToken` placeholder).
- `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on each install step.

Files: `ci.yml` (lint/typecheck/test), `e2e.yml` (playwright), `pr-check.yml` (ci-readiness), `security.yml` (npm-audit/owasp/license).

## Validation
This PR's own CI is the test: if the jobs that install deps go green, the private `@afixt` packages are resolving with auth. No application code changed.

**Compare:** https://github.com/AFixt/lexic-a11y/compare/develop...feature/ci-private-npm-auth