### PR TITLE
ci: bring private @afixt npm auth to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,6 @@ jobs:
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Debug npm auth (temporary)
-        run: |
-          echo "Token length: ${#NODE_AUTH_TOKEN}"
-          echo "whoami:"; npm whoami || echo "whoami FAILED (token invalid/empty)"
-          echo "private dep view:"; npm view @afixt/test-utils version || echo "view FAILED (no read access)"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Install dependencies
         run: npm ci
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Debug npm auth (temporary)
+        run: |
+          echo "Token length: ${#NODE_AUTH_TOKEN}"
+          echo "whoami:"; npm whoami || echo "whoami FAILED (token invalid/empty)"
+          echo "private dep view:"; npm view @afixt/test-utils version || echo "view FAILED (no read access)"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Install dependencies
         run: npm ci
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Run ESLint
         run: npm run lint --if-present
@@ -59,9 +62,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check for TypeScript config
         id: check-ts
@@ -87,9 +93,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check for test script
         id: check-tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,9 +22,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -71,11 +71,14 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         if: steps.detect.outputs.type == 'node'
         run: npm ci --ignore-scripts
         continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Run lint check
         if: steps.detect.outputs.type == 'node'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,9 +41,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Run npm audit
         run: npm audit --audit-level=high
@@ -90,9 +93,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: OWASP Dependency Check
         uses: dependency-check/Dependency-Check_Action@main
@@ -131,9 +137,12 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install license-checker
         run: npm install -g license-checker


### PR DESCRIPTION
Propagates the CI npm-auth fix (merged to `develop` in #70) to `main`, so `main`'s push- and PR-triggered workflows can install the private `@afixt` devDependencies.

### Background
`@afixt/lexic-a11y`'s dev toolchain pulls private `@afixt` packages transitively via the `@afixt/a11y-assert` devDep. CI's `npm ci` was running unauthenticated and 404'ing. Two things were wrong:
1. **No auth wiring** in the workflows — fixed in #70 (adds `registry-url` + `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to all 8 `npm ci` steps).
2. **A stale repo-level `NPM_TOKEN` secret** (a dead 40-char legacy token, registry returned `401`) was shadowing the valid **org-level** `NPM_TOKEN`. The repo-level secret has been removed, so the org token now applies.

With both addressed, CI on #70 went fully green (`npm ci` installs 1512 packages; Lint/Tests/TypeScript/Playwright/Security all pass).

### This PR
Brings those workflow changes onto `main`. No application code, no version bump, no package republish (workflow files aren't in the published `files`).

**Compare:** https://github.com/AFixt/lexic-a11y/compare/main...develop