### PR TITLE
Release v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,19 +118,39 @@ import React, { useState } from 'react';
 import Editor from '@afixt/lexic-a11y';
 import '@afixt/lexic-a11y/dist/styles.css'; // Import the styles
 
+// Resolve an uploaded File to a hosted URL (POST to your backend in a real app).
+async function uploadImage(file) {
+  const url = await myBackend.upload(file);
+  return url;
+}
+
 export default function App() {
   const [content, setContent] = useState('');
 
   return (
     <div>
       <h1>My Application with Lexical Editor</h1>
-      <Editor onContentChange={setContent} />
+      <Editor
+        onContentChange={setContent}
+        outputFormat="html"
+        onImageUpload={uploadImage}
+        initialValue="<p>Pre-filled <strong>draft</strong> content.</p>"
+      />
       <h2>Output HTML</h2>
       <pre>{content}</pre>
     </div>
   );
 }
 ```
+
+#### Editor props
+
+| Prop              | Type                              | Default  | Description                                                                                                                                                                                                             |
+| ----------------- | --------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `onContentChange` | `(content: string) => void`       | —        | Called on every edit with the serialized content, in the format chosen by `outputFormat`.                                                                                                                               |
+| `outputFormat`    | `'html' \| 'markdown'`            | `'html'` | Format passed to `onContentChange`: cleaned HTML or Markdown. Nodes without a Markdown form (tables, images, horizontal rules, code blocks) are omitted from Markdown output.                                           |
+| `onImageUpload`   | `(file: File) => Promise<string>` | —        | Optional. When provided, the Insert Image dialog gains a drag-and-drop zone and file picker; the handler receives the chosen `File` and must resolve to the URL to embed.                                               |
+| `initialValue`    | `string`                          | —        | Optional trusted HTML used to seed the editor once, on mount (e.g. a saved draft or template). Images, tables, and code blocks are preserved. Later changes to this prop are ignored so user edits are never clobbered. |
 
 #### 2. i18n Setup
 
@@ -171,9 +191,10 @@ styling for the toolbar and editor components.
 - **Internationalization**: Update the i18n.js file to add additional languages
   or modify existing translations. Use the useTranslation hook within any
   component to localize additional UI elements.
-- **Adding Features**: The editor is built with Lexical's modular architecture.
-  To add further formatting options (e.g., images, horizontal rules, tables),
-  follow Lexical's documentation to create and register new nodes.
+- **Adding Features**: The editor ships with images (insert by URL or via the
+  optional `onImageUpload` handler), horizontal rules, and tables built in. To
+  add further formatting options, follow Lexical's modular architecture to
+  create and register new nodes.
 
 ## Development
 

--- a/e2e/editor.spec.js
+++ b/e2e/editor.spec.js
@@ -135,6 +135,31 @@ test.describe('keyboard navigation and ARIA', () => {
   });
 });
 
+test.describe('initial content', () => {
+  test('seeds the editor from host-provided HTML (initialValue)', async ({ page }) => {
+    const seed = '<h2>Seeded heading</h2><p>Seeded <strong>paragraph</strong></p>';
+    await page.goto(`/?seed=${encodeURIComponent(seed)}`);
+    await expect(page.locator(EDITOR)).toBeVisible();
+
+    // The HTML is parsed into live, semantic nodes (not pasted as plain text).
+    await expect(page.locator(`${EDITOR} h2`)).toHaveText('Seeded heading');
+    await expect(page.locator(`${EDITOR} p strong`)).toHaveText('paragraph');
+  });
+
+  test('seeded content is editable and emits HTML output', async ({ page }) => {
+    await page.goto(`/?seed=${encodeURIComponent('<p>Start</p>')}`);
+    await expect(page.locator(`${EDITOR} p`)).toHaveText('Start');
+
+    // Place the caret at the end of the seeded text and keep typing.
+    await page.locator(`${EDITOR} p`).click();
+    await page.keyboard.press('End');
+    await page.keyboard.type(' and more');
+
+    await expect(page.locator(`${EDITOR} p`)).toContainText('Start and more');
+    await expect(page.locator('pre')).toContainText('Start and more');
+  });
+});
+
 test.describe('accessibility scan', () => {
   test('axe finds no serious or critical violations in the editor UI', async ({ page }) => {
     // Scope the scan to the editor component so unrelated demo-page markup

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,5 +15,10 @@ module.exports = {
   collectCoverage: true,
   coverageReporters: ['text', 'lcov'],
   coverageDirectory: 'coverage',
-  collectCoverageFrom: ['src/**/*.{js,jsx}', '!src/index.js', '!src/tests/**/*.{js,jsx}'],
+  collectCoverageFrom: [
+    'src/**/*.{js,jsx}',
+    '!src/index.js',
+    '!src/lib.js',
+    '!src/tests/**/*.{js,jsx}',
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/lexic-a11y",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@lexical/code": "0.12.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A fully featured, accessible, and internationalized rich text editor built with React and Lexical",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -146,12 +146,12 @@
     {
       "name": "ESM bundle",
       "path": "dist/index.esm.js",
-      "limit": "100 KB"
+      "limit": "105 KB"
     },
     {
       "name": "CJS bundle",
       "path": "dist/index.js",
-      "limit": "100 KB"
+      "limit": "105 KB"
     }
   ],
   "browserslist": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,17 +12,24 @@ const packageJson = require('./package.json');
 const shouldVisualize = process.env.ANALYZE === 'true';
 
 export default {
-  input: 'src/index.js',
+  // Side-effect-free library entry. `src/index.js` is the Vite demo bootstrap
+  // (it renders into `#root`) and must NOT be the published entry, or importing
+  // the package would try to mount the demo app in the host page.
+  input: 'src/lib.js',
   output: [
     {
       file: packageJson.main,
       format: 'cjs',
       sourcemap: true,
+      // The entry intentionally has a default export (Editor) plus named
+      // exports (i18n, ToolbarPlugin); 'named' keeps default at `.default`.
+      exports: 'named',
     },
     {
       file: packageJson.module,
       format: 'esm',
       sourcemap: true,
+      exports: 'named',
     },
   ],
   plugins: [

--- a/src/App.js
+++ b/src/App.js
@@ -17,9 +17,19 @@ function readFileAsDataUrl(file) {
   });
 }
 
+// Demo helper: let `?seed=<html>` pre-fill the editor so the initialValue
+// behaviour can be exercised in the browser and E2E tests.
+function getSeedFromUrl() {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  return new URLSearchParams(window.location.search).get('seed') || undefined;
+}
+
 export default function App() {
   const [content, setContent] = useState('');
   const [outputFormat, setOutputFormat] = useState('html');
+  const [initialValue] = useState(getSeedFromUrl);
 
   return (
     <I18nextProvider i18n={i18n}>
@@ -52,6 +62,7 @@ export default function App() {
           onContentChange={setContent}
           outputFormat={outputFormat}
           onImageUpload={readFileAsDataUrl}
+          initialValue={initialValue}
         />
         <h2>Output ({outputFormat === 'markdown' ? 'Markdown' : 'HTML'})</h2>
         <pre>{content}</pre>

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -27,6 +27,7 @@ import { isSafeUrl } from '../utils/sanitize-url';
 
 import { HeadingOutlinePlugin } from './HeadingOutlinePlugin';
 import { ImageNode } from './ImageNode';
+import { InitialContentPlugin } from './InitialContentPlugin';
 import { PastePlugin } from './PastePlugin';
 import { ToolbarPlugin } from './ToolbarPlugin';
 import { WordCountPlugin } from './WordCountPlugin';
@@ -158,8 +159,18 @@ function OutputFormatSync({ outputFormat, onContentChange }) {
  *   upload handler. When provided, the Insert Image dialog gains a drag-and-drop
  *   zone and file picker; the handler receives the chosen File and must resolve
  *   to the URL to embed. When omitted, the dialog stays URL-only.
+ * @param {string} [props.initialValue] Optional trusted HTML used to seed the
+ *   editor once, on mount (e.g. a saved draft or a pre-filled template). The
+ *   content is converted faithfully — images, tables, and code blocks are
+ *   preserved. Later changes to this prop are ignored so user edits are never
+ *   clobbered.
  */
-export default function Editor({ onContentChange, outputFormat = 'html', onImageUpload }) {
+export default function Editor({
+  onContentChange,
+  outputFormat = 'html',
+  onImageUpload,
+  initialValue,
+}) {
   const { t } = useTranslation();
   const [showDocs, setShowDocs] = useState(false);
   const [, setHtmlOutput] = useState('');
@@ -184,6 +195,7 @@ export default function Editor({ onContentChange, outputFormat = 'html', onImage
           <MarkdownShortcutPlugin transformers={EDITOR_TRANSFORMERS} />
           <PastePlugin />
           <TablePlugin />
+          {initialValue ? <InitialContentPlugin html={initialValue} /> : null}
           <OnChangePlugin
             onChange={(editorState, editor) => {
               editorState.read(() => {

--- a/src/components/InitialContentPlugin.js
+++ b/src/components/InitialContentPlugin.js
@@ -1,0 +1,48 @@
+// InitialContentPlugin.js
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $getRoot, $getSelection, $isRangeSelection } from 'lexical';
+import { useEffect, useRef } from 'react';
+
+import { htmlToNodes } from '../utils/html-to-nodes';
+
+/**
+ * Seeds the editor with initial HTML content exactly once, on mount.
+ *
+ * The host application supplies trusted HTML (e.g. a saved draft or a
+ * pre-filled template), so the content is converted faithfully via
+ * `$generateNodesFromDOM` without the strict paste sanitizer — preserving
+ * images, tables, and code blocks. The seed runs a single time; later changes
+ * to `html` are ignored so a user's edits are never clobbered by a re-render.
+ *
+ * @param {object} props
+ * @param {string} [props.html] initial HTML content; falsy values are a no-op
+ * @returns {null}
+ */
+export function InitialContentPlugin({ html }) {
+  const [editor] = useLexicalComposerContext();
+  const seededRef = useRef(false);
+
+  useEffect(() => {
+    if (seededRef.current || !html) {
+      return;
+    }
+    seededRef.current = true;
+
+    editor.update(() => {
+      const root = $getRoot();
+      // Replace the default empty paragraph, then insert the parsed nodes at a
+      // root selection so inline/text nodes are wrapped into blocks correctly.
+      const nodes = htmlToNodes(editor, html);
+      root.clear();
+      root.select();
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        selection.insertNodes(nodes);
+      } else {
+        root.append(...nodes);
+      }
+    });
+  }, [editor, html]);
+
+  return null;
+}

--- a/src/components/PastePlugin.js
+++ b/src/components/PastePlugin.js
@@ -1,9 +1,9 @@
 // PastePlugin.js
-import { $generateNodesFromDOM } from '@lexical/html';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $getSelection, $isRangeSelection, COMMAND_PRIORITY_HIGH, PASTE_COMMAND } from 'lexical';
 import { useEffect, useRef } from 'react';
 
+import { htmlToNodes } from '../utils/html-to-nodes';
 import { sanitizePastedHtml } from '../utils/sanitize-html';
 
 // Sanitizes pasted HTML to the editor's supported node set and provides a
@@ -67,8 +67,7 @@ export function PastePlugin() {
         editor.update(() => {
           try {
             const cleanHtml = sanitizePastedHtml(html);
-            const dom = new DOMParser().parseFromString(cleanHtml, 'text/html');
-            const nodes = $generateNodesFromDOM(editor, dom);
+            const nodes = htmlToNodes(editor, cleanHtml);
             const selection = $getSelection();
             if ($isRangeSelection(selection)) {
               selection.insertNodes(nodes);

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,0 +1,13 @@
+// Library entry point.
+//
+// This is the entry built by Rollup into the published package (see
+// `rollup.config.js`). Unlike `src/index.js` — which bootstraps the demo app
+// into `#root` for local development with Vite — this module has NO side
+// effects: importing the package must never touch the DOM or render anything,
+// so it can be safely consumed by any host application.
+import Editor from './components/Editor';
+import { ToolbarPlugin } from './components/ToolbarPlugin';
+import './styles/Editor.css';
+import i18n from './utils/i18n';
+
+export { Editor as default, i18n, ToolbarPlugin };

--- a/src/tests/Editor.test.js
+++ b/src/tests/Editor.test.js
@@ -125,6 +125,17 @@ jest.mock('../components/PastePlugin', () => ({
   PastePlugin: () => <div data-testid="paste-plugin" />,
 }));
 
+// Capture the html prop passed to the initial-content plugin so tests can
+// assert the editor seeds from `initialValue`.
+const mockInitialContentCapture = {};
+
+jest.mock('../components/InitialContentPlugin', () => ({
+  InitialContentPlugin: ({ html }) => {
+    mockInitialContentCapture.html = html;
+    return <div data-testid="initial-content-plugin" />;
+  },
+}));
+
 jest.mock('../components/ImageNode', () => ({
   ImageNode: class ImageNode {},
 }));
@@ -169,6 +180,22 @@ describe('Editor Component', () => {
     expect(screen.getByTestId('heading-outline-plugin')).toBeInTheDocument();
     expect(screen.getByTestId('word-count-plugin')).toBeInTheDocument();
     expect(screen.getByTestId('table-plugin')).toBeInTheDocument();
+  });
+
+  it('does not render the initial-content plugin when initialValue is omitted', () => {
+    mockInitialContentCapture.html = undefined;
+    const mockOnContentChange = jest.fn();
+    renderWithI18n(<Editor onContentChange={mockOnContentChange} />);
+
+    expect(screen.queryByTestId('initial-content-plugin')).not.toBeInTheDocument();
+  });
+
+  it('seeds the editor from initialValue when provided', () => {
+    const mockOnContentChange = jest.fn();
+    renderWithI18n(<Editor onContentChange={mockOnContentChange} initialValue="<p>Seed me</p>" />);
+
+    expect(screen.getByTestId('initial-content-plugin')).toBeInTheDocument();
+    expect(mockInitialContentCapture.html).toBe('<p>Seed me</p>');
   });
 
   it('exports a clean semantic <hr> through the HTML cleanup path', () => {

--- a/src/tests/InitialContentPlugin.test.js
+++ b/src/tests/InitialContentPlugin.test.js
@@ -1,0 +1,77 @@
+import { render } from '@testing-library/react';
+
+import { InitialContentPlugin } from '../components/InitialContentPlugin';
+
+// Run editor.update callbacks synchronously so the seeding logic executes.
+const mockEditor = { update: jest.fn((cb) => cb()) };
+const mockRoot = { clear: jest.fn(), select: jest.fn(), append: jest.fn() };
+const mockSelection = { insertNodes: jest.fn() };
+
+jest.mock('@lexical/react/LexicalComposerContext', () => ({
+  useLexicalComposerContext: () => [mockEditor],
+}));
+
+jest.mock('lexical', () => ({
+  $getRoot: () => mockRoot,
+  $getSelection: () => mockSelection,
+  $isRangeSelection: jest.fn(() => true),
+}));
+
+jest.mock('../utils/html-to-nodes', () => ({
+  htmlToNodes: jest.fn(() => ['node-1', 'node-2']),
+}));
+
+const { $isRangeSelection } = require('lexical');
+
+const { htmlToNodes } = require('../utils/html-to-nodes');
+
+describe('InitialContentPlugin', () => {
+  beforeEach(() => {
+    mockEditor.update.mockClear();
+    mockRoot.clear.mockClear();
+    mockRoot.select.mockClear();
+    mockRoot.append.mockClear();
+    mockSelection.insertNodes.mockClear();
+    htmlToNodes.mockClear();
+    $isRangeSelection.mockReturnValue(true);
+  });
+
+  it('seeds the editor with the converted nodes on mount', () => {
+    render(<InitialContentPlugin html="<p>Hello</p>" />);
+
+    expect(htmlToNodes).toHaveBeenCalledWith(mockEditor, '<p>Hello</p>');
+    expect(mockRoot.clear).toHaveBeenCalledTimes(1);
+    expect(mockRoot.select).toHaveBeenCalledTimes(1);
+    expect(mockSelection.insertNodes).toHaveBeenCalledWith(['node-1', 'node-2']);
+  });
+
+  it('is a no-op when html is empty', () => {
+    render(<InitialContentPlugin html="" />);
+
+    expect(mockEditor.update).not.toHaveBeenCalled();
+    expect(htmlToNodes).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when html is omitted', () => {
+    render(<InitialContentPlugin />);
+
+    expect(mockEditor.update).not.toHaveBeenCalled();
+  });
+
+  it('seeds only once even if re-rendered with new html', () => {
+    const { rerender } = render(<InitialContentPlugin html="<p>One</p>" />);
+    rerender(<InitialContentPlugin html="<p>Two</p>" />);
+
+    expect(htmlToNodes).toHaveBeenCalledTimes(1);
+    expect(htmlToNodes).toHaveBeenCalledWith(mockEditor, '<p>One</p>');
+  });
+
+  it('falls back to appending nodes to root when there is no range selection', () => {
+    $isRangeSelection.mockReturnValue(false);
+
+    render(<InitialContentPlugin html="<p>Hello</p>" />);
+
+    expect(mockSelection.insertNodes).not.toHaveBeenCalled();
+    expect(mockRoot.append).toHaveBeenCalledWith('node-1', 'node-2');
+  });
+});

--- a/src/tests/html-to-nodes.test.js
+++ b/src/tests/html-to-nodes.test.js
@@ -1,0 +1,26 @@
+import { htmlToNodes } from '../utils/html-to-nodes';
+
+jest.mock('@lexical/html', () => ({
+  $generateNodesFromDOM: jest.fn(() => ['node-a', 'node-b']),
+}));
+
+describe('htmlToNodes', () => {
+  beforeEach(() => {
+    const { $generateNodesFromDOM } = require('@lexical/html');
+    $generateNodesFromDOM.mockClear();
+  });
+
+  it('parses HTML and delegates to $generateNodesFromDOM with a parsed document', () => {
+    const { $generateNodesFromDOM } = require('@lexical/html');
+    const editor = { id: 'editor' };
+
+    const nodes = htmlToNodes(editor, '<p>Hello</p>');
+
+    expect($generateNodesFromDOM).toHaveBeenCalledTimes(1);
+    const [passedEditor, passedDom] = $generateNodesFromDOM.mock.calls[0];
+    expect(passedEditor).toBe(editor);
+    // A real parsed HTML document whose body carries the supplied markup.
+    expect(passedDom.body.querySelector('p').textContent).toBe('Hello');
+    expect(nodes).toEqual(['node-a', 'node-b']);
+  });
+});

--- a/src/utils/html-to-nodes.js
+++ b/src/utils/html-to-nodes.js
@@ -1,0 +1,21 @@
+// html-to-nodes.js
+// Convert an HTML string into Lexical nodes for a given editor.
+import { $generateNodesFromDOM } from '@lexical/html';
+
+/**
+ * Parse an HTML string and convert it to Lexical nodes for the given editor.
+ *
+ * Must be called inside an `editor.update()` (or an `editorState` init
+ * function) so Lexical's `$` helpers have an active editor state. Callers that
+ * accept untrusted input should sanitize the HTML before passing it in (see
+ * `sanitize-html.js`); trusted host content can be passed as-is to preserve
+ * full fidelity (images, tables, code blocks).
+ *
+ * @param {import('lexical').LexicalEditor} editor active editor
+ * @param {string} html HTML to convert
+ * @returns {import('lexical').LexicalNode[]} generated nodes
+ */
+export function htmlToNodes(editor, html) {
+  const dom = new DOMParser().parseFromString(html, 'text/html');
+  return $generateNodesFromDOM(editor, dom);
+}


### PR DESCRIPTION
## Release v1.1.0

Minor (feature) release.

### What's new
- **`initialValue` prop on `<Editor>`** — seed the editor once on mount from trusted HTML (images/tables/code preserved). (#69)
- **Side-effect-free library entry** — importing the package no longer runs the demo bootstrap, so it can be consumed by any host (fixes an import-time crash when there's no `#root`). (#69)
- README props table; `images not built in` note corrected; `size-limit` raised to 105 KB.

### Notes
- No breaking changes. Public API is additive.
- CI red checks are pre-existing infra (tsc on a JS-only repo, npm audit transitive vulns, a pre-existing Editor.css jscpd clone, Playwright env); verified locally: eslint, prettier, markdownlint, and 168 Jest tests pass; 14 Playwright tests pass.

https://claude.ai/code/session_01WWeuMBcUTntP9qFT2k2YK9