### PR TITLE
Release v1.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,64 @@ jobs:
         run: npm test
         env:
           CI: true
+
+  peer-compat:
+    # React is a peer dependency, so the version in devDependencies is only one
+    # point in the supported range. Build and test against each major we claim
+    # to support, so widening the range stays honest.
+    name: React ${{ matrix.react }} peer compatibility
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        react: ["18", "19"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install React ${{ matrix.react }}
+        run: npm install --no-save react@${{ matrix.react }} react-dom@${{ matrix.react }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Assert a single React copy is installed
+        # The bug this job guards against (AFixt/afixt-investigator#1053) was a
+        # DUPLICATE React, not a missing one — a nested copy silently breaks
+        # hooks in consumers while the build and tests here still pass. If
+        # react ever returns to `dependencies`, this step fails with 2.
+        run: |
+          npm ls react --all 2>&1 | head -30
+          npm ls react --json --all 2>/dev/null | node -e '
+            const data = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+            const found = new Set();
+            (function walk(node) {
+              for (const [name, child] of Object.entries(node.dependencies || {})) {
+                if (name === "react" && child.version) found.add(child.version);
+                walk(child);
+              }
+            })(data);
+            console.log("react versions in tree:", [...found].join(", ") || "(none)");
+            if (found.size !== 1) {
+              console.error(`::error::Expected exactly 1 React version, found ${found.size}`);
+              process.exit(1);
+            }
+          '
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+        env:
+          CI: true

--- a/README.md
+++ b/README.md
@@ -18,16 +18,26 @@ editing more accessible to all users.
 ## What It Does
 
 - Rich Text Editing: Offers essential text formatting including bold, italic,
-  underline, strikethrough, and a full range of headings (H1–H6).
+  underline, strikethrough, inline code, and a full range of headings (H1–H6).
+- Block Content: Blockquotes, fenced code blocks, horizontal rules, tables with
+  a real header row, and images that require alt text (or an explicit
+  "decorative" opt-out).
 - List Support: Create and manage ordered and unordered lists with proper
   semantic structure.
 - Link Management: Insert and edit hyperlinks with an accessible dialog
-  interface.
+  interface, with URL scheme validation that rejects unsafe protocols.
+- Markdown Shortcuts: Type `#`, `>`, `-`, `1.`, `**bold**`, and friends to
+  format as you go; content can also be serialized to Markdown.
+- Live Document Outline: A running list of the document's headings, with
+  WCAG-aligned warnings for skipped heading levels and multiple H1s.
+- Word and Character Count: Debounced counts surfaced in a polite live region.
+- Paste Sanitization: Pasted markup from Word or Google Docs is cleaned to
+  semantic HTML; Ctrl/Cmd+Shift+V pastes as plain text.
 - Keyboard Shortcuts: Implements a variety of keyboard shortcuts for quick
   formatting actions (e.g., Ctrl/Cmd+B for bold, Ctrl/Cmd+Alt+1 for Heading 1)
   and efficient navigation.
 - Documentation: Provides an overlay with available keyboard shortcuts and usage
-  tips.
+  tips (Ctrl/Cmd+D).
 - Internationalization (i18n): Integrated with react-i18next to allow
   localization of toolbar labels and prompts, making it adaptable for
   multi-language projects.
@@ -38,35 +48,63 @@ editing more accessible to all users.
 ## Features
 
 - Core Formatting Options:
-  - Text Styling: Bold, Italic, Underline, Strikethrough.
+  - Text Styling: Bold, Italic, Underline, Strikethrough, inline code.
   - Headings: H1 through H6 with both toolbar buttons and keyboard shortcuts.
 - List Formatting:
   - Ordered Lists: Create numbered lists with proper semantic structure.
   - Unordered Lists: Create bullet lists with proper semantic structure.
 - Content Elements:
   - Links: Insert and edit hyperlinks with an accessible dialog.
-- Keyboard Shortcuts:
-  - Basic formatting: Ctrl/Cmd+B for bold, Ctrl/Cmd+I for italic, Ctrl/Cmd+U for
-    underline.
-  - Heading shortcuts: Ctrl/Cmd+Alt+[1–6] for H1–H6.
-  - List shortcuts: Ctrl/Cmd+Shift+7 for ordered lists, Ctrl/Cmd+Shift+8 for
-    unordered lists.
-  - Link shortcut: Ctrl/Cmd+K to insert or edit links.
-- Documentation:
-  - Keyboard Shortcuts Help: Overlay displaying all available keyboard commands.
+  - Images: Insert by URL, or via the optional `onImageUpload` handler with a
+    drag-and-drop zone and file picker. Alt text is required before the image
+    can be inserted, unless it is explicitly marked decorative (`alt=""`).
+  - Tables: Insert with a header row; exported with `scope="col"`.
+  - Blockquotes, fenced code blocks, and horizontal rules.
+- Output Formats:
+  - Clean HTML (utility classes and Lexical's sizing markup stripped) or
+    Markdown, selected with the `outputFormat` prop.
 - Internationalization (i18n):
   - Built-in support using react-i18next.
   - Easy to add new languages and localize toolbar and prompt texts.
 - Accessibility (WCAG Compliant):
   - ARIA roles and labels throughout the UI.
-  - Fully keyboard accessible.
+  - Fully keyboard accessible, including a roving-tabindex toolbar.
   - Semantic HTML output for screen readers and other assistive technologies.
+
+### Keyboard shortcuts
+
+On macOS use <kbd>Cmd</kbd> wherever <kbd>Ctrl</kbd> is shown. The same list is
+available in-app from the help overlay (<kbd>Ctrl</kbd>+<kbd>D</kbd>).
+
+| Shortcut             | Action                    |
+| -------------------- | ------------------------- |
+| `Ctrl+B` / `I` / `U` | Bold / Italic / Underline |
+| `Ctrl+Shift+X`       | Strikethrough             |
+| `Ctrl+E`             | Inline code               |
+| `Ctrl+Shift+E`       | Code block                |
+| `Ctrl+\`             | Clear formatting          |
+| `Ctrl+Alt+[1–6]`     | Heading 1–6               |
+| `Ctrl+Shift+7`       | Ordered (numbered) list   |
+| `Ctrl+Shift+8`       | Unordered (bullet) list   |
+| `Ctrl+Shift+Q`       | Blockquote                |
+| `Ctrl+K`             | Insert / edit link        |
+| `Ctrl+Shift+M`       | Insert image              |
+| `Ctrl+Shift+L`       | Insert table              |
+| `Ctrl+Shift+-`       | Horizontal rule           |
+| `Ctrl+Shift+V`       | Paste as plain text       |
+| `Ctrl+D`             | Toggle the help overlay   |
+| `Escape`             | Close the open dialog     |
+
+The toolbar is a single tab stop with arrow-key roving focus; `Home` and `End`
+jump to the first and last control.
 
 ## Installation
 
 ### Prerequisites
 
-- Node.js (v20+; version pinned in `.nvmrc` / `.node-version`)
+- Node.js — `package.json` requires v20+, but the repo pins **v22** in `.nvmrc`
+  / `.node-version` (and CI runs `lts/*`). Use 22: the `@afixt/a11y-assert` test
+  dependency declares `engines.node >= 22`.
 - npm v10+ (enforced via `engine-strict=true` in `.npmrc`)
 - React (v16.8+, v17.0.0+, or v18.0.0+ for Hooks support)
 - Homebrew (macOS/Linux) — used by the bootstrap script to install security
@@ -77,7 +115,7 @@ editing more accessible to all users.
 1. Clone the Repository:
 
 ```bash
-git clone https://github.com/eventably/lexic-a11y.git
+git clone https://github.com/AFixt/lexic-a11y.git
 cd lexic-a11y
 ```
 
@@ -152,16 +190,33 @@ export default function App() {
 | `onImageUpload`   | `(file: File) => Promise<string>` | —        | Optional. When provided, the Insert Image dialog gains a drag-and-drop zone and file picker; the handler receives the chosen `File` and must resolve to the URL to embed.                                               |
 | `initialValue`    | `string`                          | —        | Optional trusted HTML used to seed the editor once, on mount (e.g. a saved draft or template). Images, tables, and code blocks are preserved. Later changes to this prop are ignored so user edits are never clobbered. |
 
+#### TypeScript
+
+The package ships hand-maintained declarations at `dist/index.d.ts` (the source
+is JavaScript — see [ADR 0002](./docs/adr/0002-remain-on-javascript.md)). No
+`@types/...` package is needed:
+
+```typescript
+import Editor, { ToolbarPlugin, i18n } from '@afixt/lexic-a11y';
+import type { EditorProps, OutputFormat } from '@afixt/lexic-a11y';
+```
+
+`npm run types:check` compiles the declarations under `strict`, and
+`src/tests/public-api.test.js` fails if they drift from the library's real
+exports.
+
 #### 2. i18n Setup
 
-Make sure your project wraps the application with an i18n provider:
+The package exports its configured `i18next` instance as a **named** export
+alongside the default `Editor` export. Wrap your application with an i18n
+provider:
 
 ```javascript
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { I18nextProvider } from 'react-i18next';
-import i18n from '@afixt/lexic-a11y/dist/i18n';
+import { i18n } from '@afixt/lexic-a11y';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -178,19 +233,23 @@ styling for the toolbar and editor components.
 
 ### Customizing the Editor
 
-- **Theme**: The editor accepts a theme object via the configuration in
-  Editor.js that lets you define class names for various parts of the editor.
+- **Theme**: Lexical class names for each node type are defined in the `theme`
+  object in `src/components/Editor.js`. It is not currently exposed as a prop —
+  change it in source (or fork) to rename the classes.
 - **Custom Styling**: Customize colors, fonts, and spacing by overriding the CSS
-  classes to match your project's design guidelines.
+  classes from `dist/styles.css` (built from `src/styles/Editor.css`) to match
+  your project's design guidelines.
 
 ### Extending the Editor
 
-- **Keyboard Shortcuts**: The shortcuts are registered in ToolbarPlugin.js using
-  event listeners. You can modify the key combinations or add new ones as
-  needed.
-- **Internationalization**: Update the i18n.js file to add additional languages
-  or modify existing translations. Use the useTranslation hook within any
-  component to localize additional UI elements.
+- **Keyboard Shortcuts**: The shortcuts are registered in
+  `src/components/ToolbarPlugin.js` with a document-level `keydown` listener.
+  You can modify the key combinations or add new ones as needed. (Bold, italic,
+  and underline are deliberately left to Lexical's `RichTextPlugin` — handling
+  them again there applies the format twice.)
+- **Internationalization**: Update `src/utils/i18n.js` to add additional
+  languages or modify existing translations. Use the `useTranslation` hook
+  within any component to localize additional UI elements.
 - **Adding Features**: The editor ships with images (insert by URL or via the
   optional `onImageUpload` handler), horizontal rules, and tables built in. To
   add further formatting options, follow Lexical's modular architecture to
@@ -208,8 +267,8 @@ To run the editor in a development environment:
 npm start
 ```
 
-This will launch the application in development mode. Open
-<http://localhost:3000> to view it in your browser.
+This launches the Vite dev server (configured in `vite.config.js`) and opens
+<http://localhost:4001> automatically.
 
 1. Making Changes:
 
@@ -241,10 +300,14 @@ no stale pre-built bundle to rebuild. See
 You can also try the editor directly on CodeSandbox without installing anything
 locally:
 
-[![Edit lexic-a11y](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/eventably/lexic-a11y/tree/develop/sandbox)
+[![Edit lexic-a11y](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/AFixt/lexic-a11y/tree/develop/sandbox)
 
-This opens our dedicated sandbox demo where you can interact with the editor and
-see how it works.
+This opens the `sandbox/` demo. Note that it is a **deliberately simplified,
+standalone** rebuild of the editor (bold/italic/underline/strikethrough, H1–H3,
+lists) rather than the packaged component — it exists so CodeSandbox can run
+without building the library. For the full feature set (tables, images, code
+blocks, horizontal rules, the link dialog, and every keyboard shortcut), run
+`npm run example` locally.
 
 ### End-to-end tests
 
@@ -296,25 +359,27 @@ We welcome contributions from the community! If you'd like to contribute:
 
 ### Available scripts
 
-| Script                  | Purpose                                       |
-| ----------------------- | --------------------------------------------- |
-| `npm start`             | Start Vite dev server (demo)                  |
-| `npm run build`         | Build the library (Rollup → `dist/`)          |
-| `npm run build:analyze` | Build with bundle visualizer report           |
-| `npm test`              | Run the Jest test suite                       |
-| `npm run test:e2e`      | Run the Playwright E2E suite                  |
-| `npm run lint`          | Run ESLint                                    |
-| `npm run lint:css`      | Run Stylelint                                 |
-| `npm run lint:md`       | Run markdownlint-cli2                         |
-| `npm run format`        | Run Prettier (write mode)                     |
-| `npm run format:check`  | Run Prettier in check mode                    |
-| `npm run dupes`         | Run jscpd duplication check                   |
-| `npm run size`          | Enforce `size-limit` budgets                  |
-| `npm run links`         | Check markdown links with `lychee`            |
-| `npm run security`      | Run npm audit + OSV + Semgrep + trufflehog    |
-| `npm run license:check` | Verify production dependency licenses         |
-| `npm run check`         | Lint + stylelint + markdown + format:check    |
-| `npm run check:all`     | Full local gate (used by the `pre-push` hook) |
+| Script                  | Purpose                                        |
+| ----------------------- | ---------------------------------------------- |
+| `npm start`             | Start Vite dev server (demo, port 4001)        |
+| `npm run example`       | Open the feature-tour example                  |
+| `npm run build`         | Build the library (Rollup → `dist/`)           |
+| `npm run build:analyze` | Build with bundle visualizer report            |
+| `npm test`              | Run the Jest test suite                        |
+| `npm run test:e2e`      | Run the Playwright E2E suite                   |
+| `npm run lint`          | Run ESLint                                     |
+| `npm run lint:css`      | Run Stylelint                                  |
+| `npm run lint:md`       | Run markdownlint-cli2                          |
+| `npm run types:check`   | Typecheck the published `.d.ts` under `strict` |
+| `npm run format`        | Run Prettier (write mode)                      |
+| `npm run format:check`  | Run Prettier in check mode                     |
+| `npm run dupes`         | Run jscpd duplication check                    |
+| `npm run size`          | Enforce `size-limit` budgets                   |
+| `npm run links`         | Check markdown links with `lychee`             |
+| `npm run security`      | Run npm audit + OSV + Semgrep + trufflehog     |
+| `npm run license:check` | Verify production dependency licenses          |
+| `npm run check`         | Lint + stylelint + markdown + format + types   |
+| `npm run check:all`     | Full local gate (used by the `pre-push` hook)  |
 
 > **Accessibility test tooling:** `npm test` runs automated WCAG assertions via
 > [`@afixt/a11y-assert`](https://www.npmjs.com/package/@afixt/a11y-assert), a

--- a/docs/adr/0001-standardize-tooling-stack.md
+++ b/docs/adr/0001-standardize-tooling-stack.md
@@ -20,7 +20,7 @@ We adopt the tooling listed in issue #14 with the following scope constraints:
 - **No TypeScript migration** — the project stays on JavaScript. TS-specific
   rules and `tsconfig.json` are out of scope.
 - **No test framework migration** — Jest stays. Vitest migration and
-  `@afix/a11y-assert` integration are deferred.
+  `@afixt/a11y-assert` integration are deferred.
 - **Express / SEO / SSR tooling is skipped** — this is a React library, not an
   application. Items like `helmet`, `zod`, `react-helmet-async`, `llms.txt`,
   `schema-dts`, and sitemap generation do not apply.
@@ -38,7 +38,7 @@ We adopt the tooling listed in issue #14 with the following scope constraints:
 - **Security CVE scans (osv-scanner, semgrep) run manually or on schedule**, not
   as part of `check:all`. The existing dev-only vulnerabilities in Parcel's
   transitive dependencies would otherwise block every push.
-- **`@afix/a11y-assert`, Lighthouse CI, Playwright, React Compiler** are
+- **`@afixt/a11y-assert`, Lighthouse CI, Playwright, React Compiler** are
   deferred. The first is testing-related (out of scope); the others are
   application concerns that do not fit a library.
 
@@ -75,13 +75,27 @@ We adopt the tooling listed in issue #14 with the following scope constraints:
   `lychee`). The pre-commit hook degrades gracefully if `trufflehog` is absent
   but logs a warning.
 
+### Follow-up status (as of 2026-07-19)
+
+This section records what has since changed; the decision text above is left as
+the snapshot it was at the time of the decision.
+
+- **Playwright and `@afixt/a11y-assert` are no longer deferred.** Both were
+  adopted afterward — a Playwright E2E suite with an axe scan
+  (`npm run test:e2e`, `.github/workflows/e2e.yml`) and component-level
+  accessibility assertions in `src/tests/accessibility.test.js`. Vitest,
+  Lighthouse CI, and React Compiler remain deferred.
+- The TypeScript decision was reaffirmed and recorded separately in
+  [ADR 0002](./0002-remain-on-javascript.md).
+- `size-limit` budgets have since been raised from 100 KB to 105 KB.
+
 ### Follow-ups
 
 - Refactor `ToolbarPlugin.js` to bring it under the complexity thresholds.
 - Fix the CSS a11y warnings (font-size thresholds, prefers-reduced-motion, focus
   states on hover selectors).
 - Replace `role="dialog"`/`role="presentation"` JSX with native elements.
-- Consider migrating tests to Vitest and integrating `@afix/a11y-assert` at the
+- Consider migrating tests to Vitest and integrating `@afixt/a11y-assert` at the
   component level once the above refactors land.
 
 ## References

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ This starts the Vite dev server and opens
 The editor is seeded on mount (via the `initialValue` prop) with content that
 exercises every block type:
 
-- Headings (`h1`–`h3`) — feeding the live document outline
+- Headings (one `h1` plus several `h2`s) — feeding the live document outline
 - Blockquote
 - Ordered and unordered lists
 - A table with a real header row (exported with `scope="col"`)

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   // Playwright owns everything under e2e/
   testPathIgnorePatterns: ['/node_modules/', '<rootDir>/e2e/'],
   moduleNameMapper: {
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '\\.(css|less|scss|sass)$': '<rootDir>/jest.styleMock.js',
   },
   transform: {
     '^.+\\.(js|jsx)$': 'babel-jest',

--- a/jest.styleMock.js
+++ b/jest.styleMock.js
@@ -1,0 +1,13 @@
+// Stub for CSS imports under Jest (see `moduleNameMapper` in jest.config.js).
+//
+// Behaves like `identity-obj-proxy`: any property lookup returns the property
+// name, so a component reading `styles.toolbar` gets the string 'toolbar'. That
+// package was referenced by the config but never installed, so the mapping
+// threw the moment a test imported a module that pulls in CSS (e.g. src/lib.js).
+// Implemented locally to keep the dependency surface flat.
+module.exports = new Proxy(
+  {},
+  {
+    get: (target, key) => (key === '__esModule' ? false : key),
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,6 @@
         "ajv": "^8.18.0",
         "i18next": "^23.0.0",
         "lexical": "^0.12.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-i18next": "^13.0.0"
       },
       "devDependencies": {
@@ -41,7 +39,7 @@
         "@rollup/plugin-node-resolve": "^15.0.0",
         "@size-limit/preset-small-lib": "11.2.0",
         "@testing-library/jest-dom": "^6.0.0",
-        "@testing-library/react": "^14.0.0",
+        "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "^14.0.0",
         "@vitejs/plugin-react": "^5.2.0",
         "babel-jest": "^29.0.0",
@@ -70,6 +68,8 @@
         "parcel": "^2.14.4",
         "prettier": "^3.8.3",
         "prettier-plugin-organize-imports": "4.3.0",
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
         "rollup": "^2.80.0",
         "rollup-plugin-peer-deps-external": "^2.2.0",
         "rollup-plugin-postcss": "^4.0.0",
@@ -88,8 +88,8 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7972,52 +7972,31 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
-      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^9.0.0",
-        "@types/react-dom": "^18.0.0"
+        "@babel/runtime": "^7.12.5"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
-      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "deep-equal": "^2.0.5"
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -8076,7 +8055,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8223,36 +8203,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.26",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
-      "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -10518,14 +10468,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -10675,39 +10617,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-is": {
@@ -10870,7 +10779,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -11194,27 +11104,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-iterator-helpers": {
@@ -13693,23 +13582,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -15449,6 +15321,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -16616,6 +16489,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -16640,6 +16514,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -18074,23 +17949,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -19513,6 +19371,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -19528,6 +19387,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -19947,28 +19807,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-error-boundary": {
@@ -20014,7 +19870,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.16.0",
@@ -20805,13 +20662,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/scslre": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@lexical/rich-text": "^0.12.0",
         "@lexical/selection": "^0.12.6",
         "@lexical/table": "^0.12.0",
-        "ajv": "^8.18.0",
         "i18next": "^23.0.0",
         "lexical": "^0.12.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
@@ -8687,6 +8686,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12382,6 +12382,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -12439,6 +12440,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15622,6 +15624,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -20373,6 +20376,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/lexic-a11y",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@lexical/code": "0.12.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.0.0",
+        "@types/react": "18.3.26",
         "@vitejs/plugin-react": "^5.2.0",
         "babel-jest": "^29.0.0",
         "eslint": "9.39.4",
@@ -8230,8 +8231,7 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.26",
@@ -8239,7 +8239,6 @@
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -10523,8 +10522,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "npm": ">=10.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@lexical/code": "0.12.6",
@@ -79,8 +79,6 @@
     "ajv": "^8.18.0",
     "i18next": "^23.0.0",
     "lexical": "^0.12.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-i18next": "^13.0.0"
   },
   "devDependencies": {
@@ -99,7 +97,7 @@
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@size-limit/preset-small-lib": "11.2.0",
     "@testing-library/jest-dom": "^6.0.0",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "^14.0.0",
     "@vitejs/plugin-react": "^5.2.0",
     "babel-jest": "^29.0.0",
@@ -128,6 +126,8 @@
     "parcel": "^2.14.4",
     "prettier": "^3.8.3",
     "prettier-plugin-organize-imports": "4.3.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "rollup": "^2.80.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-postcss": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@lexical/rich-text": "^0.12.0",
     "@lexical/selection": "^0.12.6",
     "@lexical/table": "^0.12.0",
-    "ajv": "^8.18.0",
     "i18next": "^23.0.0",
     "lexical": "^0.12.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:css:fix": "stylelint 'src/**/*.css' --fix",
     "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules' '#dist' '#build' '#coverage'",
     "lint:md:fix": "markdownlint-cli2 --fix '**/*.md' '#node_modules' '#dist' '#build' '#coverage'",
+    "types:check": "tsc --noEmit --strict --skipLibCheck --moduleResolution bundler --module esnext --target es2020 --jsx react-jsx src/index.d.ts",
     "dupes": "jscpd . --config .jscpd.json",
     "dupes:ci": "jscpd . --config .jscpd.json --threshold 5",
     "format": "prettier --write .",
@@ -39,7 +40,7 @@
     "security": "npm-run-all -p security:audit security:osv security:semgrep security:secrets",
     "license:check": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;Python-2.0;WTFPL;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "license:report": "license-checker-rseidelsohn --production --csv --out reports/licenses.csv",
-    "check": "npm-run-all -p lint lint:css lint:md format:check",
+    "check": "npm-run-all -p lint lint:css lint:md format:check types:check",
     "check:all": "npm-run-all -s check test build dupes size license:check security:audit security:secrets",
     "ci": "npm run check:all",
     "prepare": "husky",
@@ -56,8 +57,19 @@
     "accessibility",
     "i18n"
   ],
-  "author": "",
+  "author": "Karl Groves <karlgroves@gmail.com>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AFixt/lexic-a11y.git"
+  },
+  "bugs": {
+    "url": "https://github.com/AFixt/lexic-a11y/issues"
+  },
+  "homepage": "https://github.com/AFixt/lexic-a11y#readme",
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=10.0.0"
@@ -101,6 +113,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
+    "@types/react": "18.3.26",
     "@vitejs/plugin-react": "^5.2.0",
     "babel-jest": "^29.0.0",
     "eslint": "9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A fully featured, accessible, and internationalized rich text editor built with React and Lexical",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 
 import babel from '@rollup/plugin-babel';
@@ -10,6 +11,21 @@ import { visualizer } from 'rollup-plugin-visualizer';
 
 const packageJson = require('./package.json');
 const shouldVisualize = process.env.ANALYZE === 'true';
+
+// The source is JavaScript, so there is no `tsc` step to emit declarations.
+// `src/index.d.ts` is hand-maintained; copy it to the path `package.json`
+// advertises as `types` so TypeScript consumers resolve real types instead of
+// silently falling back to `any`.
+function copyTypeDeclarations() {
+  return {
+    name: 'copy-type-declarations',
+    // `writeBundle` runs after the bundle is on disk, so the output directory
+    // already exists — no mkdir needed.
+    writeBundle() {
+      fs.copyFileSync(path.resolve('src/index.d.ts'), path.resolve(packageJson.types));
+    },
+  };
+}
 
 export default {
   // Side-effect-free library entry. `src/index.js` is the Vite demo bootstrap
@@ -49,6 +65,7 @@ export default {
       minimize: true,
     }),
     terser(),
+    copyTypeDeclarations(),
     shouldVisualize &&
       visualizer({
         filename: 'reports/bundle-stats.html',

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,13 +1,21 @@
 # Lexical A11y Editor Demo
 
-This sandbox demonstrates the use of lexic-a11y, an accessible rich text editor
-built with React and Lexical.
+This sandbox is a **simplified, standalone** demo of lexic-a11y, an accessible
+rich text editor built with React and Lexical.
+
+It deliberately does **not** import the published package. It rebuilds a small
+subset of the editor from Lexical directly (see `src/App.js` and
+`src/ToolbarPlugin.js`) so that CodeSandbox can run it without building the
+library first. For the full feature set — tables, images, code blocks,
+horizontal rules, the link dialog, the document outline, word count, paste
+sanitization, and the complete keyboard shortcut map — run `npm run example`
+from the repository root.
 
 ## Features Showcased
 
 - Accessible rich text editor with keyboard support
 - Text formatting (bold, italic, underline, strikethrough)
-- Heading formatting (H1, H2, H3)
+- Heading formatting (H1, H2, H3) and a Paragraph reset, via toolbar buttons
 - List support (ordered and unordered)
 - Proper ARIA attributes and accessibility features
 - i18n support with react-i18next
@@ -20,16 +28,22 @@ The editor is ready to use! You can:
 1. Type in the editor
 2. Use the toolbar for formatting
 3. See the generated HTML output below
-4. Try keyboard shortcuts:
+4. Try the keyboard shortcuts Lexical provides natively:
    - Bold: Ctrl/Cmd+B
    - Italic: Ctrl/Cmd+I
    - Underline: Ctrl/Cmd+U
-   - Headings: Ctrl/Cmd+Alt+1 through 6
+
+   The heading, list, and link shortcuts (`Ctrl/Cmd+Alt+[1-6]`,
+   `Ctrl/Cmd+Shift+7`/`8`, `Ctrl/Cmd+K`, …) are registered by the full package's
+   `ToolbarPlugin` and are **not** wired up in this sandbox — use the toolbar
+   buttons here, or run the local feature-tour example for the whole shortcut
+   map.
 
 ## About lexic-a11y
 
-This is a standalone demo of the lexic-a11y package, which provides an
-accessible, internationalized rich text editor built with React and Lexical.
+lexic-a11y provides an accessible, internationalized rich text editor built with
+React and Lexical, published as
+[`@afixt/lexic-a11y`](https://www.npmjs.com/package/@afixt/lexic-a11y).
 
 For more information, visit the
-[full repository](https://github.com/eventably/lexic-a11y).
+[full repository](https://github.com/AFixt/lexic-a11y).

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,77 @@
+// Public type declarations for @afixt/lexic-a11y.
+//
+// The source is JavaScript (see docs/adr/0002-remain-on-javascript.md), so these
+// declarations are hand-maintained rather than emitted by `tsc`. They describe
+// the exports of `src/lib.js` — the entry Rollup builds into `dist/` — and are
+// copied to `dist/index.d.ts` by the build. Keep them in sync when the public
+// API changes; `npm run types:check` verifies they compile under `strict`.
+
+import type { i18n as I18n } from 'i18next';
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
+
+/** Serialization format passed to `onContentChange`. */
+export type OutputFormat = 'html' | 'markdown';
+
+export interface EditorProps {
+  /**
+   * Called on every edit with the serialized document, in the format chosen by
+   * `outputFormat`.
+   */
+  onContentChange: (content: string) => void;
+
+  /**
+   * Format passed to `onContentChange`. Nodes without a Markdown form (tables,
+   * images, horizontal rules, code blocks) are omitted from Markdown output.
+   *
+   * @defaultValue 'html'
+   */
+  outputFormat?: OutputFormat;
+
+  /**
+   * Optional async upload handler. When provided, the Insert Image dialog gains
+   * a drag-and-drop zone and file picker; the handler receives the chosen file
+   * and must resolve to the URL to embed. When omitted, the dialog stays
+   * URL-only.
+   */
+  onImageUpload?: (file: File) => Promise<string>;
+
+  /**
+   * Optional trusted HTML used to seed the editor once, on mount (e.g. a saved
+   * draft or a pre-filled template). Images, tables, and code blocks are
+   * preserved. Later changes to this prop are ignored so user edits are never
+   * clobbered.
+   */
+  initialValue?: string;
+}
+
+/**
+ * The accessible rich text editor. Self-contained: it creates its own Lexical
+ * composer, so it does not need to be wrapped in one.
+ */
+declare function Editor(props: EditorProps): ReactElement;
+
+export default Editor;
+
+export interface ToolbarPluginProps {
+  /** Whether the keyboard-shortcut help overlay is currently open. */
+  showDocs: boolean;
+  /** State setter used to toggle the help overlay (also bound to Ctrl/Cmd+D). */
+  setShowDocs: Dispatch<SetStateAction<boolean>>;
+  /** See {@link EditorProps.onImageUpload}. */
+  onImageUpload?: (file: File) => Promise<string>;
+}
+
+/**
+ * The editor toolbar, exported for advanced use. It reads the active editor
+ * from Lexical's composer context, so it must be rendered inside a
+ * `LexicalComposer`. Most consumers should render {@link Editor} instead, which
+ * already includes it.
+ */
+export declare function ToolbarPlugin(props: ToolbarPluginProps): ReactElement;
+
+/**
+ * The package's pre-configured `i18next` instance, with the editor's English
+ * strings registered. Pass it to `I18nextProvider`, or call `addResourceBundle`
+ * on it to add languages.
+ */
+export declare const i18n: I18n;

--- a/src/styles/Editor.css
+++ b/src/styles/Editor.css
@@ -193,22 +193,6 @@
   color: var(--primary-dark);
 }
 
-@media screen and (prefers-reduced-motion: reduce) {
-  .close-docs-button {
-    background: transparent;
-    border: none;
-    font-size: 24px;
-    cursor: pointer;
-    color: var(--text-light);
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: none;
-  }
-}
-
 .close-docs-button {
   background: transparent;
   border: none;
@@ -352,23 +336,6 @@ kbd {
   background-color: var(--primary-light);
   border-color: var(--primary-color);
   color: var(--primary-dark);
-}
-
-@media screen and (prefers-reduced-motion: reduce) {
-  .editor-toolbar button {
-    height: 36px;
-    min-width: 36px;
-    background-color: var(--background);
-    border: 1px solid var(--border-color);
-    color: var(--text-color);
-    cursor: pointer;
-    font-size: 14px;
-    padding: 0 10px;
-    transition: none;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
 }
 
 .editor-toolbar button {
@@ -574,15 +541,6 @@ kbd {
   font-size: 14px;
 }
 
-@media screen and (prefers-reduced-motion: reduce) {
-  .form-group input {
-    padding: 8px 12px;
-    border: 1px solid var(--border-color);
-    font-size: 14px;
-    transition: none;
-  }
-}
-
 .form-group input {
   padding: 8px 12px;
   border: 1px solid var(--border-color);
@@ -618,12 +576,6 @@ kbd {
   margin: 0;
   color: var(--text-light);
   font-size: 14px;
-}
-
-@media screen and (prefers-reduced-motion: reduce) {
-  .upload-button {
-    transition: none;
-  }
 }
 
 .upload-button {
@@ -680,50 +632,13 @@ kbd {
   margin-top: 10px;
 }
 
-@media screen and (prefers-reduced-motion: reduce) {
-  .cancel-button,
-  .insert-button {
-    padding: 8px 16px;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: none;
-  }
-}
-
-@media screen and (prefers-reduced-motion: reduce) {
-  .cancel-button,
-  .insert-button {
-    padding: 8px 16px;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: none;
-  }
-}
-
-@media screen and (prefers-reduced-motion: reduce) {
-  .cancel-button,
-  .insert-button {
-    padding: 8px 16px;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: none;
-  }
-}
-
-@media screen and (prefers-reduced-motion: reduce) {
-  .cancel-button,
-  .insert-button {
-    padding: 8px 16px;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: none;
-  }
-}
-
+/* Reduced motion for these two is handled by the consolidated block at the end
+   of this file. The rule only matches a single selector, so it cannot see the
+   grouped `.cancel-button, .insert-button` override there — and its autofix
+   injects a copy of this rule *above* itself, which is dead code (a media query
+   adds no specificity, so this rule would still win on source order). Disabled
+   here to stop `stylelint --fix` re-creating that. */
+/* stylelint-disable-next-line a11y/media-prefers-reduced-motion */
 .cancel-button,
 .insert-button {
   padding: 8px 16px;
@@ -855,4 +770,58 @@ kbd {
   border: 1px solid var(--border-color);
   overflow-x: auto;
   white-space: pre;
+}
+
+/*
+ * Honour the user's reduced-motion preference.
+ *
+ * Every animated rule in this file transitions via `var(--transition)`, so
+ * neutralising the variable here disables all of them at once — and covers any
+ * rule added later without needing a matching per-selector override.
+ *
+ * It lives at the end of the file deliberately. A media query adds no
+ * specificity, so source order decides the cascade. The per-selector
+ * `transition: none` blocks this replaces were each placed immediately *before*
+ * the rule they were meant to override, so the base rule's
+ * `transition: var(--transition)` always won and the preference was silently
+ * ignored.
+ */
+@media screen and (prefers-reduced-motion: reduce) {
+  :root {
+    --transition: none;
+  }
+
+  /* Suppress the toolbar buttons' decorative lift on hover/focus/active. */
+  .editor-toolbar button:hover,
+  .editor-toolbar button:focus,
+  .editor-toolbar button:active {
+    transform: none;
+  }
+
+  /*
+   * Redundant given the `--transition` override above, but `a11y/media-prefers-
+   * reduced-motion` matches selectors literally and cannot see through the
+   * custom property. Listing them keeps the rule active for any future
+   * hard-coded transition instead of switching it off project-wide.
+   */
+  .close-docs-button {
+    transition: none;
+  }
+
+  .editor-toolbar button {
+    transition: none;
+  }
+
+  .form-group input {
+    transition: none;
+  }
+
+  .upload-button {
+    transition: none;
+  }
+
+  .cancel-button,
+  .insert-button {
+    transition: none;
+  }
 }

--- a/src/tests/public-api.test.js
+++ b/src/tests/public-api.test.js
@@ -1,0 +1,46 @@
+// Guards the published type declarations against drifting from the real
+// exports.
+//
+// `src/index.d.ts` is hand-maintained (the source is JavaScript — see
+// docs/adr/0002-remain-on-javascript.md), so nothing stops someone adding,
+// renaming, or removing an export in `src/lib.js` without touching the
+// declarations. `npm run types:check` only proves the .d.ts compiles; this test
+// proves it describes the module Rollup actually builds.
+import fs from 'fs';
+import path from 'path';
+
+import * as lib from '../lib';
+
+const declarations = fs.readFileSync(path.join(__dirname, '..', 'index.d.ts'), 'utf8');
+
+/** Names declared as value exports (not `export type`/`export interface`). */
+function declaredValueExports(source) {
+  const names = new Set();
+  // `export declare function Foo(` / `export declare const Foo:`
+  for (const match of source.matchAll(/export declare (?:function|const)\s+(\w+)/g)) {
+    names.add(match[1]);
+  }
+  // `export default Editor;` — the default export's binding name is irrelevant
+  // to consumers, so record it under the key Node/Rollup expose it as.
+  if (/^export default \w+;/m.test(source)) {
+    names.add('default');
+  }
+  return names;
+}
+
+describe('published type declarations', () => {
+  it('declares exactly the value exports of the library entry', () => {
+    const runtime = new Set(Object.keys(lib));
+    expect(declaredValueExports(declarations)).toEqual(runtime);
+  });
+
+  it('exports the editor as the default export', () => {
+    expect(typeof lib.default).toBe('function');
+  });
+
+  it('exports the toolbar plugin and the configured i18n instance', () => {
+    expect(typeof lib.ToolbarPlugin).toBe('function');
+    expect(typeof lib.i18n.t).toBe('function');
+    expect(lib.i18n.language).toBe('en');
+  });
+});

--- a/usecases/README.md
+++ b/usecases/README.md
@@ -24,21 +24,18 @@ accessibility finding.
 Toolbar toggle state is asserted through `aria-pressed` so each use case also
 verifies the control semantics, not just the visual result.
 
-## Assumed accessible names
+## Accessible names these depend on
 
-These use cases address controls by accessible names that are introduced by two
-other open PRs, which fix labels that previously rendered as raw i18n keys.
-**Merge those PRs before this one** so the names resolve:
+Use cases address controls by accessible name, all defined in
+`src/utils/i18n.js`:
 
-- The editor surface: `Editor content` — `editorContent` aria-label added in PR
-  #50 (`feature/18-e2e-tests`).
+- `Editor content` — the editor surface's `aria-label` (`editorContent`).
 - `Bullet List`, `Numbered List`, `Show Help` — `bulletList` / `numberedList` /
-  `showHelp` translations added in PR #50 (`feature/18-e2e-tests`).
-- `Insert Link` — the link button's aria-label, renamed from the uninformative
-  `Link` to `insertLink` in PR #51 (`feature/8-a11y-assert`).
+  `showHelp`.
+- `Insert Link` — the link button's `aria-label` (`insertLink`).
 
-Once those PRs land on `develop`, a use case that still fails to locate one of
-these controls means the accessible name has regressed.
+These all resolve on `develop` today. A use case that fails to locate one of
+these controls therefore means the accessible name has regressed.
 
 ## Running them
 
@@ -49,7 +46,8 @@ execute the use cases (Node >= 22):
 npm install --no-save @afixt/usecase-runner @playwright/test
 npx playwright install chromium
 
-# Start the demo app in another shell
+# Start the demo app in another shell — it must be reachable at
+# http://localhost:4001, the `start_location` every use case declares
 npm start
 
 # Validate the YAML


### PR DESCRIPTION
Release **v1.1.2** — a fix and documentation release. No breaking changes.

## What's in it

### Consumer-facing

**React 19 support, and React is no longer a runtime dependency** (#76). `react`/`react-dom` were listed in **both** `peerDependencies` and `dependencies`. Because of the latter, a consumer on React 19 got no resolution error — npm silently installed a second, nested React 18 alongside the root React 19, hooks crossed instances, and the editor mounted nothing. Peers now allow `^19.0.0`, and React moved to `devDependencies`. The published bundle is unchanged (Rollup already externalised from `peerDependencies`); this changes only what npm installs for consumers. Unblocks AFixt/afixt-investigator#1053.

**TypeScript declarations are actually shipped** (#75). `package.json` advertised `"types": "dist/index.d.ts"`, but nothing ever generated that file — TS consumers silently resolved the package to `any`. Real declarations now build into `dist/`, covering `Editor`, `ToolbarPlugin`, `i18n`, `EditorProps`, `ToolbarPluginProps` and `OutputFormat`.

**`prefers-reduced-motion` is honoured** (#75). None of `Editor.css`'s eight reduced-motion blocks did anything: each sat immediately *before* the rule it was meant to override, and a media query adds no specificity, so source order meant `transition: var(--transition)` always won. Verified fixed in Chromium — computed `transition` goes from `0.2s ease-in-out` to `none`.

**Unused `ajv` dependency removed** (#75), clearing a high-severity `fast-uri` advisory. Nothing imported it; every consumer was installing it, and the vulnerable transitive, for nothing.

### Documentation

Every Markdown file audited against the source (#75). Corrected the clone/CodeSandbox URLs (`eventably` → `AFixt`), the dev-server port (3000 → 4001), an i18n import path that pointed at a file which does not exist, the Node version, and a feature list and shortcut table that were both years stale. Added the missing `repository`, `bugs`, `homepage`, `author` and `publishConfig` fields.

## Verification

`npm run check:all` exits 0 on the merged result: **171 tests across 15 suites under React 19**, 0 clones, 0 production vulnerabilities, bundles 100.23 kB / 100.14 kB against the 105 kB budget, React confirmed external in `dist`.

## Compare

https://github.com/AFixt/lexic-a11y/compare/v1.1.1...develop
