### PR TITLE
chore: remove axe-core and tooling that depends on it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,8 @@ code in this repository.
 
 ## Tooling
 
-- ESLint flat config in `eslint.config.mjs` — includes react, jsx-a11y, sonarjs,
-  security, unicorn, import-x, promise, n, jsdoc, no-secrets. Structural rules
+- ESLint flat config in `eslint.config.mjs` — includes react, sonarjs, security,
+  unicorn, import-x, promise, n, jsdoc, no-secrets. Structural rules
   (complexity, max-depth, cognitive-complexity) are **warnings** so pre-existing
   code smell doesn't block new work; the errors tier is reserved for correctness
   and security.
@@ -72,8 +72,19 @@ This project follows **Git Flow**. You MUST adhere to this branching strategy:
 - Ensure proper aria-\* attributes on interactive elements
 - Follow i18n patterns using react-i18next's useTranslation hook
 - Always provide alt text for images and proper ARIA attributes
-- Run ESLint with jsx-a11y plugin to catch accessibility issues
 
 ## Reviewing PRs
 
 Whenever I ask to review a PR (pull request), use the `pr-review` skill.
+
+## axe-core is banned
+
+**`axe-core` must never be used in this project — directly or transitively.**
+
+- Do not add `axe-core` or any `@axe-core/*` package.
+- Do not add any dependency that pulls in `axe-core` transitively — this
+  includes `eslint-plugin-jsx-a11y`, `lighthouse` / `@lhci/cli`, `pa11y`,
+  `@storybook/addon-a11y`, `jest-axe`, `cypress-axe`, and similar.
+- Before adding any new dependency, verify with `npm ls axe-core` that it does
+  not introduce axe-core into the tree. If it does, do not add it.
+- Use `@afixt/a11y-assert` for accessibility checks instead.

--- a/README.md
+++ b/README.md
@@ -312,11 +312,9 @@ blocks, horizontal rules, the link dialog, and every keyboard shortcut), run
 ### End-to-end tests
 
 The E2E suite runs the demo app in a real browser with
-[Playwright](https://playwright.dev/) and includes an
-[axe](https://github.com/dequelabs/axe-core) accessibility scan. A rich-text
-editor's correctness is largely real-browser behavior (keyboard handling,
-selection, contenteditable quirks, ARIA state), which Jest unit tests cannot
-exercise.
+[Playwright](https://playwright.dev/). A rich-text editor's correctness is
+largely real-browser behavior (keyboard handling, selection, contenteditable
+quirks, ARIA state), which Jest unit tests cannot exercise.
 
 ```bash
 # One-time: install the Playwright browser
@@ -330,9 +328,8 @@ npm run test:e2e:headed
 ```
 
 The suite covers typing, formatting (toolbar and keyboard), lists, the link
-dialog, keyboard navigation, ARIA state assertions, and an axe scan that fails
-on serious/critical violations. CI runs it on pull requests via
-`.github/workflows/e2e.yml`.
+dialog, keyboard navigation, and ARIA state assertions. CI runs it on pull
+requests via `.github/workflows/e2e.yml`.
 
 ### Building for Production
 

--- a/e2e/editor.spec.js
+++ b/e2e/editor.spec.js
@@ -1,5 +1,4 @@
 // editor.spec.js — E2E smoke tests for the demo app in a real browser
-import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
 const EDITOR = '.editor-input';
@@ -157,28 +156,5 @@ test.describe('initial content', () => {
 
     await expect(page.locator(`${EDITOR} p`)).toContainText('Start and more');
     await expect(page.locator('pre')).toContainText('Start and more');
-  });
-});
-
-test.describe('accessibility scan', () => {
-  test('axe finds no serious or critical violations in the editor UI', async ({ page }) => {
-    // Scope the scan to the editor component so unrelated demo-page markup
-    // can't mask or add noise to the editor's own results. The toolbar and the
-    // content container are siblings under the Lexical composer (no shared
-    // wrapper), so include both — otherwise the most ARIA-heavy markup (the
-    // toolbar) would be excluded from the scan.
-    const results = await new AxeBuilder({ page })
-      .include('.editor-toolbar')
-      .include('.editor-container')
-      .analyze();
-
-    const seriousOrWorse = results.violations.filter((violation) =>
-      ['serious', 'critical'].includes(violation.impact),
-    );
-
-    expect(
-      seriousOrWorse,
-      seriousOrWorse.map((violation) => `${violation.id}: ${violation.description}`).join('\n'),
-    ).toEqual([]);
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,6 @@ import js from '@eslint/js';
 import prettier from 'eslint-config-prettier';
 import importX from 'eslint-plugin-import-x';
 import jsdoc from 'eslint-plugin-jsdoc';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
 import n from 'eslint-plugin-n';
 import noSecrets from 'eslint-plugin-no-secrets';
 import promise from 'eslint-plugin-promise';
@@ -46,7 +45,6 @@ export default [
     plugins: {
       react,
       'react-hooks': reactHooks,
-      'jsx-a11y': jsxA11y,
       sonarjs,
       security,
       unicorn,
@@ -88,22 +86,6 @@ export default [
       'react/self-closing-comp': 'error',
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',
-
-      // Accessibility
-      'jsx-a11y/alt-text': 'error',
-      'jsx-a11y/anchor-is-valid': 'error',
-      'jsx-a11y/aria-props': 'error',
-      'jsx-a11y/aria-role': 'error',
-      'jsx-a11y/aria-unsupported-elements': 'error',
-      'jsx-a11y/click-events-have-key-events': 'error',
-      'jsx-a11y/label-has-associated-control': 'error',
-      'jsx-a11y/no-autofocus': ['error', { ignoreNonDOM: true }],
-      'jsx-a11y/no-redundant-roles': 'error',
-      'jsx-a11y/no-static-element-interactions': 'error',
-      'jsx-a11y/no-noninteractive-element-interactions': 'error',
-      'jsx-a11y/prefer-tag-over-role': 'warn',
-      'jsx-a11y/role-has-required-aria-props': 'error',
-      'jsx-a11y/role-supports-aria-props': 'error',
 
       // Code quality
       'sonarjs/cognitive-complexity': ['warn', 15],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
       },
       "devDependencies": {
         "@afixt/a11y-assert": "2.1.3",
-        "@axe-core/playwright": "4.11.3",
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.2",
         "@babel/preset-react": "^7.22.0",
@@ -47,7 +46,6 @@
         "eslint-config-prettier": "9.1.2",
         "eslint-plugin-import-x": "4.16.2",
         "eslint-plugin-jsdoc": "51.4.1",
-        "eslint-plugin-jsx-a11y": "6.10.2",
         "eslint-plugin-n": "17.24.0",
         "eslint-plugin-no-secrets": "2.3.3",
         "eslint-plugin-promise": "7.2.1",
@@ -577,19 +575,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@axe-core/playwright": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
-      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "axe-core": "~4.11.4"
-      },
-      "peerDependencies": {
-        "playwright-core": ">= 1.0.0"
-      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -8968,13 +8953,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/ast-types-flow": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
-      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -9015,26 +8993,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axe-core": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
-      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/axobject-query": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/babel-jest": {
@@ -10486,13 +10444,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/damerau-levenshtein": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
-      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/dargs": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
@@ -11569,45 +11520,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
-      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
-      "dev": true,
-      "dependencies": {
-        "aria-query": "^5.3.2",
-        "array-includes": "^3.1.8",
-        "array.prototype.flatmap": "^1.3.2",
-        "ast-types-flow": "^0.0.8",
-        "axe-core": "^4.10.0",
-        "axobject-query": "^4.1.0",
-        "damerau-levenshtein": "^1.0.8",
-        "emoji-regex": "^9.2.2",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^3.3.5",
-        "language-tags": "^1.0.9",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.includes": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/eslint-plugin-n": {
@@ -15680,26 +15592,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/language-subtag-registry": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
-      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/language-tags": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
-      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "language-subtag-registry": "^0.3.20"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/leven": {
@@ -21314,21 +21206,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string.prototype.includes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
-      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
   },
   "devDependencies": {
     "@afixt/a11y-assert": "2.1.3",
-    "@axe-core/playwright": "4.11.3",
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.2",
     "@babel/preset-react": "^7.22.0",
@@ -117,7 +116,6 @@
     "eslint-config-prettier": "9.1.2",
     "eslint-plugin-import-x": "4.16.2",
     "eslint-plugin-jsdoc": "51.4.1",
-    "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-n": "17.24.0",
     "eslint-plugin-no-secrets": "2.3.3",
     "eslint-plugin-promise": "7.2.1",


### PR DESCRIPTION
## Summary

Removes `axe-core` from the dependency tree entirely, per policy. `axe-core` was pulled in **transitively** by two direct `devDependencies`, both of which are axe-tooling and have been removed:

- `@axe-core/playwright@4.11.3` → pulled `axe-core@~4.11.4`
- `eslint-plugin-jsx-a11y@6.10.2` → pulled `axe-core@^4.10.0`

After regenerating `package-lock.json`, `grep -c 'axe-core' package-lock.json` prints **0**.

## Changes

- **package.json**: removed `@axe-core/playwright` and `eslint-plugin-jsx-a11y` from `devDependencies`.
- **package-lock.json**: regenerated with `npm install --package-lock-only --ignore-scripts`; no `axe-core` remains.
- **eslint.config.mjs**: removed the `eslint-plugin-jsx-a11y` import, the `jsx-a11y` plugin registration, and all `jsx-a11y/*` rule entries. Lint config still loads (0 errors).
- **e2e/editor.spec.js**: removed the `AxeBuilder` import and the `accessibility scan` describe block; all other Playwright E2E tests are untouched and still run.
- **README.md**: dropped the axe-scan mentions from the E2E docs.
- **CLAUDE.md**: fixed the jsx-a11y tooling references and appended the "axe-core is banned" policy section.

No non-axe packages were removed. The sanctioned `@afixt/a11y-assert` and `@double-great/stylelint-a11y` dependencies are retained.

Closes #78