### PR TITLE
Release v1.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,3 +175,12 @@ jobs:
         run: npm test
         env:
           CI: true
+
+      - name: Smoke-test the built bundles
+        # The source suite cannot see build-config regressions: #80 shipped
+        # bundles that threw "React is not defined" on mount while `npm test`
+        # was green. This mounts the real dist/ artifacts under each supported
+        # React major.
+        run: npm run test:dist
+        env:
+          CI: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,31 @@ jobs:
           path: ./
           extra_args: --only-verified
 
+  # Policy check — fails if a banned package resolves in the tree
+  banned-deps:
+    name: Banned Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Check for banned dependencies
+        # The package.json `overrides` entry already neutralises axe-core, but
+        # a silent stub is a confusing failure mode. This names the dependency
+        # that pulled it in. See "axe-core is banned" in CLAUDE.md.
+        run: npm run security:banned-deps
+
   # Quick scan on every push/PR
   npm-audit:
     name: NPM Audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ code in this repository.
 - Analyze bundle: `npm run build:analyze` (writes `reports/bundle-stats.html`)
 - Run tests: `npm test`
 - Run tests with watch: `npm run test:watch`
+- Smoke-test the built bundles: `npm run test:dist` (needs `npm run build` first
+  — it mounts the real `dist/` ESM and CJS artifacts in jsdom, which the source
+  suite cannot do)
 - Lint code: `npm run lint` (JS), `npm run lint:css`, `npm run lint:md`
 - Format: `npm run format`
 - Check bundle size: `npm run size`
@@ -26,11 +29,16 @@ code in this repository.
 
 ## Tooling
 
-- ESLint flat config in `eslint.config.mjs` — includes react, jsx-a11y, sonarjs,
-  security, unicorn, import-x, promise, n, jsdoc, no-secrets. Structural rules
+- ESLint flat config in `eslint.config.mjs` — includes react, sonarjs, security,
+  unicorn, import-x, promise, n, jsdoc, no-secrets. Structural rules
   (complexity, max-depth, cognitive-complexity) are **warnings** so pre-existing
   code smell doesn't block new work; the errors tier is reserved for correctness
   and security.
+- Babel presets live **only** in `babel.config.js` — never re-declare them in
+  `rollup.config.js`'s `babel()` options. Babel merges same-named presets and
+  the programmatic options win, so repeating `@babel/preset-react` there
+  silently drops `runtime: 'automatic'` and compiles the bundles to a bare
+  `React.createElement` with nothing bound in scope (issue #80).
 - Prettier config in `.prettierrc.json` (note: MD049 in
   `.markdownlint-cli2.jsonc` aligns with Prettier's default underscore
   emphasis).
@@ -72,8 +80,31 @@ This project follows **Git Flow**. You MUST adhere to this branching strategy:
 - Ensure proper aria-\* attributes on interactive elements
 - Follow i18n patterns using react-i18next's useTranslation hook
 - Always provide alt text for images and proper ARIA attributes
-- Run ESLint with jsx-a11y plugin to catch accessibility issues
 
 ## Reviewing PRs
 
 Whenever I ask to review a PR (pull request), use the `pr-review` skill.
+
+## axe-core is banned
+
+**`axe-core` must never be used in this project — directly or transitively.**
+
+- Do not add `axe-core` or any `@axe-core/*` package.
+- Do not add any dependency that pulls in `axe-core` transitively — this
+  includes `eslint-plugin-jsx-a11y`, `lighthouse` / `@lhci/cli`, `pa11y`,
+  `@storybook/addon-a11y`, `jest-axe`, `cypress-axe`, and similar.
+- Before adding any new dependency, verify with `npm ls axe-core` that it does
+  not introduce axe-core into the tree. If it does, do not add it.
+- Use `@afixt/a11y-assert` for accessibility checks instead.
+
+The ban is enforced, not just documented:
+
+- The `overrides` entry in `package.json` maps `axe-core` to an empty stub
+  package, so even a transitive request resolves to nothing installable.
+- `npm run security:banned-deps` (in `check:all`, `security`, and the
+  `Banned Dependencies` CI job) fails and names the dependency chain that
+  requested it — the override alone would only produce a confusing runtime
+  breakage in whichever tool wanted axe-core.
+
+To ban another package, add it to `BANNED` in `scripts/check-banned-deps.mjs`
+and add a matching `overrides` entry.

--- a/README.md
+++ b/README.md
@@ -312,11 +312,9 @@ blocks, horizontal rules, the link dialog, and every keyboard shortcut), run
 ### End-to-end tests
 
 The E2E suite runs the demo app in a real browser with
-[Playwright](https://playwright.dev/) and includes an
-[axe](https://github.com/dequelabs/axe-core) accessibility scan. A rich-text
-editor's correctness is largely real-browser behavior (keyboard handling,
-selection, contenteditable quirks, ARIA state), which Jest unit tests cannot
-exercise.
+[Playwright](https://playwright.dev/). A rich-text editor's correctness is
+largely real-browser behavior (keyboard handling, selection, contenteditable
+quirks, ARIA state), which Jest unit tests cannot exercise.
 
 ```bash
 # One-time: install the Playwright browser
@@ -330,9 +328,23 @@ npm run test:e2e:headed
 ```
 
 The suite covers typing, formatting (toolbar and keyboard), lists, the link
-dialog, keyboard navigation, ARIA state assertions, and an axe scan that fails
-on serious/critical violations. CI runs it on pull requests via
-`.github/workflows/e2e.yml`.
+dialog, keyboard navigation, and ARIA state assertions. CI runs it on pull
+requests via `.github/workflows/e2e.yml`.
+
+### Built-bundle smoke tests
+
+`npm test` imports from `src/`, so it cannot see a bug introduced by the build
+itself. `npm run test:dist` mounts the real `dist/` artifacts — both the ESM and
+CJS bundles — in jsdom and asserts they render:
+
+```bash
+npm run build      # test:dist needs the artifacts
+npm run test:dist
+```
+
+This guards the class of regression that shipped in v1.1.2, where the bundles
+referenced an unbound global `React` and threw `React is not defined` on mount
+while the source suite stayed green. `npm run check:all` runs it after `build`.
 
 ### Building for Production
 
@@ -359,27 +371,29 @@ We welcome contributions from the community! If you'd like to contribute:
 
 ### Available scripts
 
-| Script                  | Purpose                                        |
-| ----------------------- | ---------------------------------------------- |
-| `npm start`             | Start Vite dev server (demo, port 4001)        |
-| `npm run example`       | Open the feature-tour example                  |
-| `npm run build`         | Build the library (Rollup → `dist/`)           |
-| `npm run build:analyze` | Build with bundle visualizer report            |
-| `npm test`              | Run the Jest test suite                        |
-| `npm run test:e2e`      | Run the Playwright E2E suite                   |
-| `npm run lint`          | Run ESLint                                     |
-| `npm run lint:css`      | Run Stylelint                                  |
-| `npm run lint:md`       | Run markdownlint-cli2                          |
-| `npm run types:check`   | Typecheck the published `.d.ts` under `strict` |
-| `npm run format`        | Run Prettier (write mode)                      |
-| `npm run format:check`  | Run Prettier in check mode                     |
-| `npm run dupes`         | Run jscpd duplication check                    |
-| `npm run size`          | Enforce `size-limit` budgets                   |
-| `npm run links`         | Check markdown links with `lychee`             |
-| `npm run security`      | Run npm audit + OSV + Semgrep + trufflehog     |
-| `npm run license:check` | Verify production dependency licenses          |
-| `npm run check`         | Lint + stylelint + markdown + format + types   |
-| `npm run check:all`     | Full local gate (used by the `pre-push` hook)  |
+| Script                         | Purpose                                        |
+| ------------------------------ | ---------------------------------------------- |
+| `npm start`                    | Start Vite dev server (demo, port 4001)        |
+| `npm run example`              | Open the feature-tour example                  |
+| `npm run build`                | Build the library (Rollup → `dist/`)           |
+| `npm run build:analyze`        | Build with bundle visualizer report            |
+| `npm test`                     | Run the Jest test suite                        |
+| `npm run test:dist`            | Smoke-test the built bundles (needs `build`)   |
+| `npm run test:e2e`             | Run the Playwright E2E suite                   |
+| `npm run lint`                 | Run ESLint                                     |
+| `npm run lint:css`             | Run Stylelint                                  |
+| `npm run lint:md`              | Run markdownlint-cli2                          |
+| `npm run types:check`          | Typecheck the published `.d.ts` under `strict` |
+| `npm run format`               | Run Prettier (write mode)                      |
+| `npm run format:check`         | Run Prettier in check mode                     |
+| `npm run dupes`                | Run jscpd duplication check                    |
+| `npm run size`                 | Enforce `size-limit` budgets                   |
+| `npm run links`                | Check markdown links with `lychee`             |
+| `npm run security`             | Run npm audit + OSV + Semgrep + trufflehog     |
+| `npm run license:check`        | Verify production dependency licenses          |
+| `npm run security:banned-deps` | Fail if a banned package resolves              |
+| `npm run check`                | Lint + stylelint + markdown + format + types   |
+| `npm run check:all`            | Full local gate (used by the `pre-push` hook)  |
 
 > **Accessibility test tooling:** `npm test` runs automated WCAG assertions via
 > [`@afixt/a11y-assert`](https://www.npmjs.com/package/@afixt/a11y-assert), a
@@ -387,6 +401,13 @@ We welcome contributions from the community! If you'd like to contribute:
 > test suite on Node 22+ (the version CI uses); Node 20 only emits an
 > `EBADENGINE` warning. It is a `devDependency` and is not part of the published
 > package or its production `license:check`.
+>
+> **`axe-core` is banned in this project**, directly and transitively. A
+> `package.json` `overrides` entry resolves it to an empty stub so it can never
+> be installed, and `npm run security:banned-deps` fails the build naming the
+> dependency that asked for it. Before adding a dependency, check it does not
+> pull in `axe-core` (`eslint-plugin-jsx-a11y`, `lighthouse`, `pa11y`,
+> `jest-axe`, and `cypress-axe` all do). Use `@afixt/a11y-assert` instead.
 
 ### Architecture decisions
 

--- a/e2e/editor.spec.js
+++ b/e2e/editor.spec.js
@@ -1,5 +1,4 @@
 // editor.spec.js — E2E smoke tests for the demo app in a real browser
-import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
 const EDITOR = '.editor-input';
@@ -157,28 +156,5 @@ test.describe('initial content', () => {
 
     await expect(page.locator(`${EDITOR} p`)).toContainText('Start and more');
     await expect(page.locator('pre')).toContainText('Start and more');
-  });
-});
-
-test.describe('accessibility scan', () => {
-  test('axe finds no serious or critical violations in the editor UI', async ({ page }) => {
-    // Scope the scan to the editor component so unrelated demo-page markup
-    // can't mask or add noise to the editor's own results. The toolbar and the
-    // content container are siblings under the Lexical composer (no shared
-    // wrapper), so include both — otherwise the most ARIA-heavy markup (the
-    // toolbar) would be excluded from the scan.
-    const results = await new AxeBuilder({ page })
-      .include('.editor-toolbar')
-      .include('.editor-container')
-      .analyze();
-
-    const seriousOrWorse = results.violations.filter((violation) =>
-      ['serious', 'critical'].includes(violation.impact),
-    );
-
-    expect(
-      seriousOrWorse,
-      seriousOrWorse.map((violation) => `${violation.id}: ${violation.description}`).join('\n'),
-    ).toEqual([]);
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,6 @@ import js from '@eslint/js';
 import prettier from 'eslint-config-prettier';
 import importX from 'eslint-plugin-import-x';
 import jsdoc from 'eslint-plugin-jsdoc';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
 import n from 'eslint-plugin-n';
 import noSecrets from 'eslint-plugin-no-secrets';
 import promise from 'eslint-plugin-promise';
@@ -46,7 +45,6 @@ export default [
     plugins: {
       react,
       'react-hooks': reactHooks,
-      'jsx-a11y': jsxA11y,
       sonarjs,
       security,
       unicorn,
@@ -88,22 +86,6 @@ export default [
       'react/self-closing-comp': 'error',
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',
-
-      // Accessibility
-      'jsx-a11y/alt-text': 'error',
-      'jsx-a11y/anchor-is-valid': 'error',
-      'jsx-a11y/aria-props': 'error',
-      'jsx-a11y/aria-role': 'error',
-      'jsx-a11y/aria-unsupported-elements': 'error',
-      'jsx-a11y/click-events-have-key-events': 'error',
-      'jsx-a11y/label-has-associated-control': 'error',
-      'jsx-a11y/no-autofocus': ['error', { ignoreNonDOM: true }],
-      'jsx-a11y/no-redundant-roles': 'error',
-      'jsx-a11y/no-static-element-interactions': 'error',
-      'jsx-a11y/no-noninteractive-element-interactions': 'error',
-      'jsx-a11y/prefer-tag-over-role': 'warn',
-      'jsx-a11y/role-has-required-aria-props': 'error',
-      'jsx-a11y/role-supports-aria-props': 'error',
 
       // Code quality
       'sonarjs/cognitive-complexity': ['warn', 15],
@@ -216,6 +198,24 @@ export default [
     },
     rules: {
       'unicorn/filename-case': 'off',
+    },
+  },
+
+  // Repo maintenance scripts — Node-only, run directly by npm scripts and CI.
+  // The base block above only matches `.js`/`.jsx`, so these need their own
+  // globals or every `console`/`process` reads as `no-undef`.
+  {
+    files: ['scripts/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      // These scripts report to a human on stdout/stderr — that is their job.
+      'no-console': 'off',
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,9 @@
 module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  // Playwright owns everything under e2e/
-  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/e2e/'],
+  // Playwright owns everything under e2e/; test/ holds the built-artifact
+  // smoke tests, which need `dist/` and run separately (jest.dist.config.js)
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/e2e/', '<rootDir>/test/'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': '<rootDir>/jest.styleMock.js',
   },

--- a/jest.dist.config.js
+++ b/jest.dist.config.js
@@ -1,0 +1,14 @@
+// Jest config for the built-artifact smoke tests (`npm run test:dist`).
+//
+// Kept separate from `jest.config.js` because these tests require `dist/` to
+// exist: the main suite runs before the build in `check:all`, so folding them
+// in would fail on a clean checkout. No coverage is collected here — the
+// bundles are minified, and `src/` coverage is the main suite's job.
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  roots: ['<rootDir>/test'],
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/lexic-a11y",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@lexical/code": "0.12.6",
@@ -24,7 +24,6 @@
       },
       "devDependencies": {
         "@afixt/a11y-assert": "2.1.3",
-        "@axe-core/playwright": "4.11.3",
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.2",
         "@babel/preset-react": "^7.22.0",
@@ -47,7 +46,6 @@
         "eslint-config-prettier": "9.1.2",
         "eslint-plugin-import-x": "4.16.2",
         "eslint-plugin-jsdoc": "51.4.1",
-        "eslint-plugin-jsx-a11y": "6.10.2",
         "eslint-plugin-n": "17.24.0",
         "eslint-plugin-no-secrets": "2.3.3",
         "eslint-plugin-promise": "7.2.1",
@@ -577,19 +575,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@axe-core/playwright": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
-      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "axe-core": "~4.11.4"
-      },
-      "peerDependencies": {
-        "playwright-core": ">= 1.0.0"
-      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -8968,13 +8953,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/ast-types-flow": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
-      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -9015,26 +8993,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axe-core": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
-      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/axobject-query": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/babel-jest": {
@@ -10486,13 +10444,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/damerau-levenshtein": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
-      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/dargs": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
@@ -11569,45 +11520,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
-      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
-      "dev": true,
-      "dependencies": {
-        "aria-query": "^5.3.2",
-        "array-includes": "^3.1.8",
-        "array.prototype.flatmap": "^1.3.2",
-        "ast-types-flow": "^0.0.8",
-        "axe-core": "^4.10.0",
-        "axobject-query": "^4.1.0",
-        "damerau-levenshtein": "^1.0.8",
-        "emoji-regex": "^9.2.2",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^3.3.5",
-        "language-tags": "^1.0.9",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.includes": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/eslint-plugin-n": {
@@ -15680,26 +15592,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/language-subtag-registry": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
-      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/language-tags": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
-      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "language-subtag-registry": "^0.3.20"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/leven": {
@@ -21314,21 +21206,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string.prototype.includes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
-      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A fully featured, accessible, and internationalized rich text editor built with React and Lexical",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -18,6 +18,7 @@
     "preview:demo": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:dist": "jest --config jest.dist.config.js",
     "lint": "eslint .",
     "lint:strict": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
@@ -37,11 +38,12 @@
     "security:osv": "osv-scanner --lockfile=package-lock.json",
     "security:semgrep": "semgrep --config=p/javascript --config=p/react --config=p/owasp-top-ten --error --metrics=off",
     "security:secrets": "trufflehog git file://. --only-verified --fail",
-    "security": "npm-run-all -p security:audit security:osv security:semgrep security:secrets",
+    "security:banned-deps": "node scripts/check-banned-deps.mjs",
+    "security": "npm-run-all -p security:audit security:osv security:semgrep security:secrets security:banned-deps",
     "license:check": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;Python-2.0;WTFPL;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "license:report": "license-checker-rseidelsohn --production --csv --out reports/licenses.csv",
     "check": "npm-run-all -p lint lint:css lint:md format:check types:check",
-    "check:all": "npm-run-all -s check test build dupes size license:check security:audit security:secrets",
+    "check:all": "npm-run-all -s check test build test:dist dupes size license:check security:audit security:secrets security:banned-deps",
     "ci": "npm run check:all",
     "prepare": "husky",
     "example": "vite --open /examples/index.html",
@@ -78,6 +80,9 @@
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
+  "overrides": {
+    "axe-core": "npm:empty-npm-package@1.0.0"
+  },
   "dependencies": {
     "@lexical/code": "0.12.6",
     "@lexical/html": "^0.12.0",
@@ -94,7 +99,6 @@
   },
   "devDependencies": {
     "@afixt/a11y-assert": "2.1.3",
-    "@axe-core/playwright": "4.11.3",
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.2",
     "@babel/preset-react": "^7.22.0",
@@ -117,7 +121,6 @@
     "eslint-config-prettier": "9.1.2",
     "eslint-plugin-import-x": "4.16.2",
     "eslint-plugin-jsdoc": "51.4.1",
-    "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-n": "17.24.0",
     "eslint-plugin-no-secrets": "2.3.3",
     "eslint-plugin-promise": "7.2.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,7 +56,14 @@ export default {
     babel({
       babelHelpers: 'bundled',
       exclude: 'node_modules/**',
-      presets: ['@babel/preset-env', '@babel/preset-react'],
+      // Presets deliberately live ONLY in `babel.config.js`. Repeating
+      // `@babel/preset-react` here overrode that file's `runtime: 'automatic'`
+      // with the classic runtime (Babel merges same-named presets, and the
+      // programmatic options win), so every component compiled to a bare
+      // `React.createElement` that nothing bound in module scope — the
+      // published bundles threw "React is not defined" on mount (#80).
+      // One source of truth keeps the built output and the test/dev transform
+      // from drifting apart again.
     }),
     commonjs(),
     postcss({

--- a/scripts/check-banned-deps.mjs
+++ b/scripts/check-banned-deps.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Fails if a banned package resolves anywhere in the installed dependency tree.
+//
+// `overrides` in package.json already stops axe-core from being *installed* —
+// anything that asks for it gets an empty stub instead. That guarantees the
+// policy but fails confusingly: the offending tool breaks at runtime with no
+// hint as to why. This check runs first and says plainly which dependency
+// dragged the banned package in.
+//
+// See the "axe-core is banned" section of CLAUDE.md.
+import { execFileSync } from 'node:child_process';
+
+/** Packages that must never appear in the tree, with the reason for the ban. */
+const BANNED = [
+  {
+    // Matches `axe-core` and every `@axe-core/*` scoped package.
+    pattern: /^(axe-core|@axe-core\/.+)$/,
+    label: 'axe-core',
+    reason: 'banned by project policy — use @afixt/a11y-assert instead',
+  },
+];
+
+/**
+ * Read the installed tree. `npm ls --all --json` exits non-zero for unrelated
+ * reasons (peer-dep warnings, extraneous packages), so the output is parsed
+ * regardless of exit status.
+ * @returns {object} the parsed dependency tree, or an empty tree on failure.
+ */
+function readTree() {
+  let stdout;
+  try {
+    stdout = execFileSync('npm', ['ls', '--all', '--json'], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (error) {
+    stdout = error.stdout;
+  }
+
+  try {
+    return JSON.parse(stdout || '{}');
+  } catch {
+    console.error('check-banned-deps: could not parse `npm ls --all --json` output.');
+    process.exit(1);
+  }
+}
+
+/**
+ * Walk the tree, collecting every path that reaches a banned package.
+ * @param {object} node a node of the `npm ls` tree.
+ * @param {string[]} trail the dependency names leading to this node.
+ * @param {Set<string>} seen resolved paths already visited (cycle guard).
+ * @returns {string[]} human-readable dependency chains, one per hit.
+ */
+function findBanned(node, trail = [], seen = new Set()) {
+  const hits = [];
+
+  for (const [name, child] of Object.entries(node.dependencies || {})) {
+    const chain = [...trail, name];
+    const banned = BANNED.find((entry) => entry.pattern.test(name));
+
+    if (banned) {
+      hits.push(`${chain.join(' > ')}  (${banned.label}: ${banned.reason})`);
+      // Don't descend into a banned package — one report per path is enough.
+      continue;
+    }
+
+    // `resolved` is absent for the root and for workspace links; fall back to
+    // the chain so those still get a cycle guard.
+    const key = child.resolved || chain.join('>');
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+
+    hits.push(...findBanned(child, chain, seen));
+  }
+
+  return hits;
+}
+
+const hits = findBanned(readTree());
+
+if (hits.length > 0) {
+  console.error('Banned dependencies found in the installed tree:\n');
+  for (const hit of hits) {
+    console.error(`  ${hit}`);
+  }
+  console.error(
+    '\nRemove the dependency that pulls it in, or replace it with a tool that ' +
+      'does not.\nSee the "axe-core is banned" section of CLAUDE.md.',
+  );
+  process.exit(1);
+}
+
+console.log('check-banned-deps: no banned dependencies in the tree.');

--- a/test/dist-smoke.test.js
+++ b/test/dist-smoke.test.js
@@ -1,0 +1,71 @@
+// Smoke tests for the PUBLISHED bundles in `dist/`.
+//
+// Everything else in the suite imports from `src/`, so a bug introduced by the
+// build itself is invisible to it. That is exactly how #80 shipped: the Rollup
+// Babel options re-declared `@babel/preset-react` without `runtime:
+// 'automatic'`, so the bundles compiled to a bare `React.createElement` that
+// nothing bound in module scope, and `<Editor>` threw "React is not defined"
+// the moment a consumer mounted it — while `npm test` stayed green.
+//
+// These tests run against real artifacts, so they need `npm run build` first;
+// `npm run test:dist` (wired into `check:all` after the build) does that.
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { render, screen } from '@testing-library/react';
+
+const DIST = path.join(__dirname, '..', 'dist');
+
+const BUNDLES = [
+  { name: 'ESM', file: 'index.esm.js' },
+  { name: 'CJS', file: 'index.js' },
+];
+
+beforeAll(() => {
+  if (!fs.existsSync(path.join(DIST, 'index.esm.js'))) {
+    throw new Error(
+      'dist/ is missing or incomplete — run `npm run build` before `npm run test:dist`.',
+    );
+  }
+});
+
+describe.each(BUNDLES)('$name bundle ($file)', ({ file }) => {
+  const bundlePath = path.join(DIST, file);
+
+  it('references no unbound global `React`', () => {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is built from __dirname, not input
+    const code = fs.readFileSync(bundlePath, 'utf8');
+
+    // With the automatic JSX runtime, JSX compiles to `react/jsx-runtime`
+    // imports and no module names `React` at all. Any surviving `React` token
+    // is therefore either the classic-runtime regression this guards against
+    // or a deliberate `import React from 'react'` — and the latter is not a
+    // pattern this package uses (see rollup.config.js). Fail on both so the
+    // build convention stays enforced rather than assumed.
+    expect(code).not.toMatch(/\bReact\b/);
+  });
+
+  it('mounts <Editor> without throwing', () => {
+    // `require` rather than a static import: the path is computed per bundle,
+    // and each bundle carries its own copy of Lexical and i18next, so they
+    // must not share module state.
+    const bundle = require(bundlePath);
+    const Editor = bundle.default;
+
+    expect(typeof Editor).toBe('function');
+
+    render(<Editor onContentChange={() => {}} />);
+
+    // The Lexical content surface is what a consumer actually types into —
+    // reaching it proves the component tree rendered, not just that the
+    // module imported.
+    expect(screen.getByRole('textbox', { name: 'Editor content' })).toBeInTheDocument();
+  });
+
+  it('exposes the documented named exports', () => {
+    const bundle = require(bundlePath);
+
+    expect(typeof bundle.ToolbarPlugin).toBe('function');
+    expect(typeof bundle.i18n.t).toBe('function');
+  });
+});


### PR DESCRIPTION
Release **v1.1.3** — patch. Replaces #85.

## Why this PR exists instead of #85

`main` enforces **required signatures** and **linear history**. #85 carried two
unsigned commits (the version bump and a conflict-resolution merge), and both
are already in `develop`'s history, so they cannot be retroactively signed
without rewriting `develop`. Squash-merging did not help — GitHub validates the
rule against the PR's existing commits.

This branch is a **single signed commit off `main`** whose tree is
byte-identical to the merged `develop` (verified with
`git diff release/1.1.3 HEAD` — empty). That satisfies both rules without an
admin bypass and without touching `develop`'s history.

## What's in it

- **#82 — `fix(build)`: compile the bundles with the automatic JSX runtime**
  (closes #80). `rollup.config.js` re-declared `@babel/preset-react` in the
  `babel()` plugin options; Babel merges same-named presets and the
  programmatic options win, so that bare entry overrode `babel.config.js`'s
  `runtime: 'automatic'`. Everything compiled with the classic runtime — 348
  `React.createElement` calls against an unbound `React`. **v1.1.2 throws
  `ReferenceError: React is not defined` on mount for every consumer.**

  Adds `npm run test:dist`, which mounts the real `dist/` ESM and CJS artifacts
  in jsdom. Verified to fail with the original `ReferenceError` when the old
  config is restored; runs in the React 18/19 peer-compat CI jobs.

- **#83 — `chore(deps)`: enforce the axe-core ban** (closes #78). `overrides`
  entry resolving axe-core to an empty stub, plus `npm run security:banned-deps`
  and a `Banned Dependencies` CI job that names the requesting dependency chain.

## User-facing changes

- `<Editor>` mounts without a global-React shim. No API changes.
- Bundles now import `react/jsx-runtime` alongside `react` / `react-dom`; all
  three stay external and are covered by the existing peer ranges.
- Size: 100.12 kB ESM / 100.08 kB CJS against the 105 kB budget.

## Known gap

Real-browser accessibility coverage removed in #79 is still unreplaced —
tracked in #84. Does not affect this release.

## Post-merge

Tag `v1.1.3`, move the floating `v1` pointer, create the GitHub release, then
**`npm publish`** — there is no publish workflow in this repo, so consumers stay
broken until that runs manually.

https://github.com/AFixt/lexic-a11y/compare/v1.1.2...release/v1.1.3-signed