### PR TITLE
chore(release): sync develop to v1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/lexic-a11y",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@lexical/code": "0.12.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A fully featured, accessible, and internationalized rich text editor built with React and Lexical",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Git Flow merge-back for the v1.1.3 release (#86).

The version bump landed on `main` as part of the signed release commit. This brings `develop`'s `package.json` and `package-lock.json` to 1.1.3 so the next release branches from a matching base, rather than re-bumping from a stale 1.1.2.

Version only — no source changes.

Merge this after #86.