### PR TITLE
feat(editor)!: opt-in showOutline prop; outline no longer injects an h2 (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ editing more accessible to all users.
 - Markdown Shortcuts: Type `#`, `>`, `-`, `1.`, `**bold**`, and friends to
   format as you go; content can also be serialized to Markdown.
 - Live Document Outline: A running list of the document's headings, with
-  WCAG-aligned warnings for skipped heading levels and multiple H1s.
+  WCAG-aligned warnings for skipped heading levels and multiple H1s. It is a
+  labelled region rather than a heading, so it never contributes to the host
+  page's heading outline, and it can be turned off entirely with
+  `showOutline={false}`.
 - Word and Character Count: Debounced counts surfaced in a polite live region.
 - Paste Sanitization: Pasted markup from Word or Google Docs is cleaned to
   semantic HTML; Ctrl/Cmd+Shift+V pastes as plain text.
@@ -189,6 +192,7 @@ export default function App() {
 | `outputFormat`    | `'html' \| 'markdown'`            | `'html'` | Format passed to `onContentChange`: cleaned HTML or Markdown. Nodes without a Markdown form (tables, images, horizontal rules, code blocks) are omitted from Markdown output.                                           |
 | `onImageUpload`   | `(file: File) => Promise<string>` | —        | Optional. When provided, the Insert Image dialog gains a drag-and-drop zone and file picker; the handler receives the chosen `File` and must resolve to the URL to embed.                                               |
 | `initialValue`    | `string`                          | —        | Optional trusted HTML used to seed the editor once, on mount (e.g. a saved draft or template). Images, tables, and code blocks are preserved. Later changes to this prop are ignored so user edits are never clobbered. |
+| `showOutline`     | `boolean`                         | `true`   | Whether to render the Document Outline panel below the editing surface. Pass `false` for short-form embedded fields (a reply box, a ticket description) where the panel is unnecessary chrome.                          |
 
 #### TypeScript
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ editing more accessible to all users.
   interface, with URL scheme validation that rejects unsafe protocols.
 - Markdown Shortcuts: Type `#`, `>`, `-`, `1.`, `**bold**`, and friends to
   format as you go; content can also be serialized to Markdown.
-- Live Document Outline: A running list of the document's headings, with
-  WCAG-aligned warnings for skipped heading levels and multiple H1s. It is a
-  labelled region rather than a heading, so it never contributes to the host
-  page's heading outline, and it can be turned off entirely with
-  `showOutline={false}`.
+- Live Document Outline: Opt in with `showOutline` for a running list of the
+  document's headings, with WCAG-aligned warnings for skipped heading levels and
+  multiple H1s. It is a labelled region rather than a heading, so it never
+  contributes to the host page's heading outline.
 - Word and Character Count: Debounced counts surfaced in a polite live region.
 - Paste Sanitization: Pasted markup from Word or Google Docs is cleaned to
   semantic HTML; Ctrl/Cmd+Shift+V pastes as plain text.
@@ -176,6 +175,7 @@ export default function App() {
         outputFormat="html"
         onImageUpload={uploadImage}
         initialValue="<p>Pre-filled <strong>draft</strong> content.</p>"
+        showOutline
       />
       <h2>Output HTML</h2>
       <pre>{content}</pre>
@@ -192,7 +192,7 @@ export default function App() {
 | `outputFormat`    | `'html' \| 'markdown'`            | `'html'` | Format passed to `onContentChange`: cleaned HTML or Markdown. Nodes without a Markdown form (tables, images, horizontal rules, code blocks) are omitted from Markdown output.                                           |
 | `onImageUpload`   | `(file: File) => Promise<string>` | —        | Optional. When provided, the Insert Image dialog gains a drag-and-drop zone and file picker; the handler receives the chosen `File` and must resolve to the URL to embed.                                               |
 | `initialValue`    | `string`                          | —        | Optional trusted HTML used to seed the editor once, on mount (e.g. a saved draft or template). Images, tables, and code blocks are preserved. Later changes to this prop are ignored so user edits are never clobbered. |
-| `showOutline`     | `boolean`                         | `true`   | Whether to render the Document Outline panel below the editing surface. Pass `false` for short-form embedded fields (a reply box, a ticket description) where the panel is unnecessary chrome.                          |
+| `showOutline`     | `boolean`                         | `false`  | Whether to render the Document Outline panel below the editing surface. Off by default, which suits short-form embedded fields (a reply box, a ticket description). Pass `true` for long-form authoring.                |
 
 #### TypeScript
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,25 @@ export default function App() {
 | `initialValue`    | `string`                          | —        | Optional trusted HTML used to seed the editor once, on mount (e.g. a saved draft or template). Images, tables, and code blocks are preserved. Later changes to this prop are ignored so user edits are never clobbered. |
 | `showOutline`     | `boolean`                         | `false`  | Whether to render the Document Outline panel below the editing surface. Off by default, which suits short-form embedded fields (a reply box, a ticket description). Pass `true` for long-form authoring.                |
 
+#### Upgrading
+
+Coming from 1.1.x, the Document Outline panel changed in two ways that affect
+existing consumers:
+
+- **It no longer renders by default.** It used to always render; it is now
+  opt-in. If you want it, pass `showOutline`:
+
+  ```jsx
+  <Editor onContentChange={setContent} showOutline />
+  ```
+
+- **Its title is a `<div>`, not an `<h2>`.** The panel is a labelled region
+  (`<section aria-label="Document Outline">`), so an embedded editor no longer
+  injects a heading into the host page's heading hierarchy. Class names
+  (`.editor-outline`, `.editor-outline-title`) are unchanged, but CSS that
+  selected the title by element — `.editor-outline h2` — needs updating to
+  `.editor-outline-title`.
+
 #### TypeScript
 
 The package ships hand-maintained declarations at `dist/index.d.ts` (the source

--- a/examples/FeatureTour.jsx
+++ b/examples/FeatureTour.jsx
@@ -96,6 +96,7 @@ export default function FeatureTour() {
           onContentChange={setContent}
           outputFormat={outputFormat}
           onImageUpload={readFileAsDataUrl}
+          showOutline
         />
 
         <p className="example-hint">

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,6 +63,7 @@ function MyApp() {
       outputFormat="html" // or "markdown"
       onContentChange={(serialized) => console.log(serialized)}
       onImageUpload={async (file) => uploadAndReturnUrl(file)}
+      showOutline // opt in to the document outline panel (off by default)
     />
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -63,6 +63,7 @@ export default function App() {
           outputFormat={outputFormat}
           onImageUpload={readFileAsDataUrl}
           initialValue={initialValue}
+          showOutline
         />
         <h2>Output ({outputFormat === 'markdown' ? 'Markdown' : 'HTML'})</h2>
         <pre>{content}</pre>

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -165,16 +165,17 @@ function OutputFormatSync({ outputFormat, onContentChange }) {
  *   preserved. Later changes to this prop are ignored so user edits are never
  *   clobbered.
  * @param {boolean} [props.showOutline] Whether to render the Document Outline
- *   panel below the editing surface. Defaults to `true`; pass `false` for
- *   short-form embedded fields (a reply box, a ticket description) where the
- *   panel is unnecessary chrome.
+ *   panel below the editing surface. Defaults to `false`, so the editor stays
+ *   minimal chrome by default and suits short-form embedded fields (a reply
+ *   box, a ticket description). Pass `true` for long-form authoring, where a
+ *   live heading map earns its space.
  */
 export default function Editor({
   onContentChange,
   outputFormat = 'html',
   onImageUpload,
   initialValue,
-  showOutline = true,
+  showOutline = false,
 }) {
   const { t } = useTranslation();
   const [showDocs, setShowDocs] = useState(false);

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -164,12 +164,17 @@ function OutputFormatSync({ outputFormat, onContentChange }) {
  *   content is converted faithfully — images, tables, and code blocks are
  *   preserved. Later changes to this prop are ignored so user edits are never
  *   clobbered.
+ * @param {boolean} [props.showOutline] Whether to render the Document Outline
+ *   panel below the editing surface. Defaults to `true`; pass `false` for
+ *   short-form embedded fields (a reply box, a ticket description) where the
+ *   panel is unnecessary chrome.
  */
 export default function Editor({
   onContentChange,
   outputFormat = 'html',
   onImageUpload,
   initialValue,
+  showOutline = true,
 }) {
   const { t } = useTranslation();
   const [showDocs, setShowDocs] = useState(false);
@@ -207,7 +212,7 @@ export default function Editor({
           />
           <OutputFormatSync outputFormat={outputFormat} onContentChange={onContentChange} />
         </div>
-        <HeadingOutlinePlugin />
+        {showOutline ? <HeadingOutlinePlugin /> : null}
         <WordCountPlugin />
       </div>
 

--- a/src/components/HeadingOutlinePlugin.js
+++ b/src/components/HeadingOutlinePlugin.js
@@ -68,7 +68,11 @@ export function HeadingOutlinePlugin() {
 
   return (
     <section className="editor-outline" aria-label={t('documentOutline')}>
-      <h2 className="editor-outline-title">{t('documentOutline')}</h2>
+      {/* Deliberately not a heading: the panel belongs to a single form control,
+          so contributing an <h2> to the host page's heading outline would
+          misrepresent the page structure (issue #88). The section's aria-label
+          already names the region for assistive technology. */}
+      <div className="editor-outline-title">{t('documentOutline')}</div>
 
       {/* Non-blocking, accessible warnings: announced politely, prefixed with
           a text marker so they are not conveyed by color alone */}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,6 +42,15 @@ export interface EditorProps {
    * clobbered.
    */
   initialValue?: string;
+
+  /**
+   * Whether to render the Document Outline panel below the editing surface.
+   * Pass `false` for short-form embedded fields (a reply box, a ticket
+   * description) where the panel is unnecessary chrome.
+   *
+   * @defaultValue true
+   */
+  showOutline?: boolean;
 }
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,10 +45,11 @@ export interface EditorProps {
 
   /**
    * Whether to render the Document Outline panel below the editing surface.
-   * Pass `false` for short-form embedded fields (a reply box, a ticket
-   * description) where the panel is unnecessary chrome.
+   * Off by default, so the editor stays minimal chrome and suits short-form
+   * embedded fields (a reply box, a ticket description). Pass `true` for
+   * long-form authoring, where a live heading map earns its space.
    *
-   * @defaultValue true
+   * @defaultValue false
    */
   showOutline?: boolean;
 }

--- a/src/styles/Editor.css
+++ b/src/styles/Editor.css
@@ -719,9 +719,12 @@ kbd {
   border: 1px solid var(--border-color);
 }
 
+/* Styled to read like the heading it used to be — it is a <div> so the panel
+   does not inject an <h2> into the host page's heading outline. */
 .editor-outline-title {
   margin: 0 0 8px;
   font-size: 1rem;
+  font-weight: 700;
 }
 
 .editor-outline-warning {

--- a/src/tests/Editor.test.js
+++ b/src/tests/Editor.test.js
@@ -168,7 +168,8 @@ describe('Editor Component', () => {
 
   it('renders the editor plugins', () => {
     const mockOnContentChange = jest.fn();
-    renderWithI18n(<Editor onContentChange={mockOnContentChange} />);
+    // showOutline is opt-in, so ask for the outline to cover every plugin here
+    renderWithI18n(<Editor onContentChange={mockOnContentChange} showOutline />);
 
     expect(screen.getByTestId('history-plugin')).toBeInTheDocument();
     expect(screen.getByTestId('horizontal-rule-plugin')).toBeInTheDocument();
@@ -182,19 +183,25 @@ describe('Editor Component', () => {
     expect(screen.getByTestId('table-plugin')).toBeInTheDocument();
   });
 
-  it('renders the outline panel by default', () => {
+  it('omits the outline panel by default', () => {
     renderWithI18n(<Editor onContentChange={jest.fn()} />);
-
-    expect(screen.getByTestId('heading-outline-plugin')).toBeInTheDocument();
-  });
-
-  it('omits the outline panel when showOutline is false', () => {
-    renderWithI18n(<Editor onContentChange={jest.fn()} showOutline={false} />);
 
     expect(screen.queryByTestId('heading-outline-plugin')).not.toBeInTheDocument();
     // The rest of the editor is unaffected
     expect(screen.getByTestId('content-editable')).toBeInTheDocument();
     expect(screen.getByTestId('word-count-plugin')).toBeInTheDocument();
+  });
+
+  it('renders the outline panel when showOutline is true', () => {
+    renderWithI18n(<Editor onContentChange={jest.fn()} showOutline />);
+
+    expect(screen.getByTestId('heading-outline-plugin')).toBeInTheDocument();
+  });
+
+  it('omits the outline panel when showOutline is explicitly false', () => {
+    renderWithI18n(<Editor onContentChange={jest.fn()} showOutline={false} />);
+
+    expect(screen.queryByTestId('heading-outline-plugin')).not.toBeInTheDocument();
   });
 
   it('does not render the initial-content plugin when initialValue is omitted', () => {

--- a/src/tests/Editor.test.js
+++ b/src/tests/Editor.test.js
@@ -182,6 +182,21 @@ describe('Editor Component', () => {
     expect(screen.getByTestId('table-plugin')).toBeInTheDocument();
   });
 
+  it('renders the outline panel by default', () => {
+    renderWithI18n(<Editor onContentChange={jest.fn()} />);
+
+    expect(screen.getByTestId('heading-outline-plugin')).toBeInTheDocument();
+  });
+
+  it('omits the outline panel when showOutline is false', () => {
+    renderWithI18n(<Editor onContentChange={jest.fn()} showOutline={false} />);
+
+    expect(screen.queryByTestId('heading-outline-plugin')).not.toBeInTheDocument();
+    // The rest of the editor is unaffected
+    expect(screen.getByTestId('content-editable')).toBeInTheDocument();
+    expect(screen.getByTestId('word-count-plugin')).toBeInTheDocument();
+  });
+
   it('does not render the initial-content plugin when initialValue is omitted', () => {
     mockInitialContentCapture.html = undefined;
     const mockOnContentChange = jest.fn();

--- a/src/tests/HeadingOutlinePlugin.test.js
+++ b/src/tests/HeadingOutlinePlugin.test.js
@@ -72,6 +72,18 @@ describe('HeadingOutlinePlugin', () => {
     expect(screen.getByText(/No headings yet/)).toBeInTheDocument();
   });
 
+  it('is a labelled region and contributes no heading to the host page', () => {
+    mockHeadings = [makeHeading('1', 'h1', 'Title')];
+
+    renderWithI18n(<HeadingOutlinePlugin />);
+
+    expect(screen.getByRole('region', { name: 'Document Outline' })).toBeInTheDocument();
+    // The panel belongs to a single form control, so its title must not land in
+    // the host page's heading outline (issue #88).
+    expect(screen.queryAllByRole('heading')).toHaveLength(0);
+    expect(screen.getByText('Document Outline')).toHaveClass('editor-outline-title');
+  });
+
   it('renders the outline reflecting the document structure', () => {
     mockHeadings = [
       makeHeading('1', 'h1', 'Title'),

--- a/src/tests/HeadingOutlinePlugin.test.js
+++ b/src/tests/HeadingOutlinePlugin.test.js
@@ -81,7 +81,8 @@ describe('HeadingOutlinePlugin', () => {
     // The panel belongs to a single form control, so its title must not land in
     // the host page's heading outline (issue #88).
     expect(screen.queryAllByRole('heading')).toHaveLength(0);
-    expect(screen.getByText('Document Outline')).toHaveClass('editor-outline-title');
+    // ...but the title is still visible as text
+    expect(screen.getByText('Document Outline')).toBeInTheDocument();
   });
 
   it('renders the outline reflecting the document structure', () => {

--- a/src/tests/accessibility.test.js
+++ b/src/tests/accessibility.test.js
@@ -157,4 +157,19 @@ describe('accessibility assertions (a11y-assert)', () => {
 
     await expectAccessible(document.body);
   });
+
+  // showOutline is off by default, so the case above no longer covers the
+  // outline panel. Assert it explicitly — the panel sits inside the host's
+  // page structure, which is exactly where its markup has to behave (#88).
+  it('editor with the outline panel shown has no violations', async () => {
+    renderWithI18n(withPageChrome(<Editor onContentChange={jest.fn()} showOutline />));
+
+    expect(screen.getByRole('region', { name: 'Document Outline' })).toBeInTheDocument();
+    // The panel must not add to the host page's heading outline: the only
+    // heading here is the page's own h1 from withPageChrome.
+    expect(screen.getAllByRole('heading')).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Editor test page');
+
+    await expectAccessible(document.body);
+  });
 });


### PR DESCRIPTION
Closes #88.

## What

The Document Outline panel was always rendered, and its title was a real
`<h2>` — so it joined the **host page's** heading hierarchy. On an embedded
short-form field (a reply box, a ticket description), a screen reader user
navigating by heading landed on "Document Outline" as though it were a content
section of the page.

Both fixes from the issue's "Suggested fix" section:

1. **The title is no longer a heading.** It renders as
   `<div class="editor-outline-title">`. The panel's `<section>` already carries
   `aria-label="Document Outline"`, so it remains a named region for assistive
   technology — it just no longer contributes to the host's heading outline. CSS
   picks up the boldness the `<h2>` used to supply, so nothing changes visually.
2. **New `showOutline` prop, defaulting to `false`.** The panel is opt-in:
   `<Editor showOutline />` renders it, and the plain `<Editor>` stays minimal
   chrome. Most embeds are short-form fields where the panel is noise; long-form
   authoring surfaces ask for it.

## Compatibility — breaking

Two visible changes for existing consumers:

- **The outline panel no longer renders by default.** Anyone who wants it must
  now pass `showOutline`. This warrants a major (or at minimum minor) version
  bump, not a patch.
- **The `<h2>` is now a `<div>`.** Class names (`.editor-outline`,
  `.editor-outline-title`) are unchanged, so the `display: none` CSS workaround
  from the issue keeps working.

The bundled demo (`src/App.js`) and the `FeatureTour` example opt in, so the
feature is still exercised end-to-end and in Playwright.

## Tests

- `HeadingOutlinePlugin.test.js`: the panel is a labelled region and renders
  zero headings.
- `Editor.test.js`: the panel is omitted by default, rendered with
  `showOutline`, and omitted with an explicit `showOutline={false}`.

Full suite: 15 suites / 175 tests passing. `types:check`, eslint, stylelint,
prettier, and markdownlint clean (only pre-existing structural warnings).
