### PR TITLE
fix(a11y): raise focus-ring contrast to 3:1 and cover it in a real browser

### DIFF
--- a/e2e/editor.spec.js
+++ b/e2e/editor.spec.js
@@ -158,3 +158,170 @@ test.describe('initial content', () => {
     await expect(page.locator('pre')).toContainText('Start and more');
   });
 });
+
+// --- Focus indicators (WCAG 2.2 SC 1.4.11 Non-text Contrast) ---
+//
+// These live here rather than in src/tests/accessibility.test.js because a
+// focus indicator is judged from computed CSS, and jsdom loads no stylesheets:
+// there, every element looks unstyled. A real browser is the only place this
+// can be measured, so the jsdom suite excludes KEYBOARD-01 and defers to these.
+
+/** Parse a computed `rgb()`/`rgba()` string into channels plus alpha. */
+const parseColor = (value) => {
+  const match = /rgba?\(([^)]+)\)/.exec(value ?? '');
+  if (!match) return null;
+  const parts = match[1].split(',').map((part) => Number.parseFloat(part.trim()));
+  const [r, g, b, a = 1] = parts;
+  return { r, g, b, a };
+};
+
+/** Flatten a translucent color onto an opaque backdrop. */
+const flatten = (fg, bg) => ({
+  r: fg.a * fg.r + (1 - fg.a) * bg.r,
+  g: fg.a * fg.g + (1 - fg.a) * bg.g,
+  b: fg.a * fg.b + (1 - fg.a) * bg.b,
+  a: 1,
+});
+
+/** WCAG relative luminance. */
+const luminance = ({ r, g, b }) => {
+  const channel = (value) => {
+    const srgb = value / 255;
+    return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+};
+
+/** WCAG contrast ratio between two opaque colors. */
+const contrastRatio = (one, two) => {
+  const [lighter, darker] = [luminance(one), luminance(two)].sort((a, b) => b - a);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+/**
+ * Read every style that could carry a focus indicator, plus the first opaque
+ * background painted behind the element (the backdrop the indicator sits on).
+ */
+const readIndicator = (page, selector) =>
+  page.evaluate((sel) => {
+    const element = document.querySelector(sel);
+    const styles = getComputedStyle(element);
+
+    // Walk ancestors for the first non-transparent background — that is what a
+    // ring drawn outside the element's border box is actually seen against.
+    let backdrop = 'rgb(255, 255, 255)';
+    for (let node = element.parentElement; node; node = node.parentElement) {
+      const background = getComputedStyle(node).backgroundColor;
+      const alpha = /rgba?\(([^)]+)\)/.exec(background);
+      if (alpha && Number.parseFloat(alpha[1].split(',')[3] ?? '1') !== 0) {
+        backdrop = background;
+        break;
+      }
+    }
+
+    return {
+      outline: `${styles.outlineStyle} ${styles.outlineWidth} ${styles.outlineColor}`,
+      outlineStyle: styles.outlineStyle,
+      outlineWidth: styles.outlineWidth,
+      outlineColor: styles.outlineColor,
+      boxShadow: styles.boxShadow,
+      backdrop,
+    };
+  }, selector);
+
+/**
+ * These controls animate with `transition: all 0.2s`, so reading the computed
+ * style the instant focus lands catches the indicator mid-animation — a
+ * transparent, zero-spread shadow that looks like "no indicator at all". Poll
+ * until two consecutive reads agree, so the assertion sees the settled value.
+ */
+const settledIndicator = async (page, selector) => {
+  let previous = await readIndicator(page, selector);
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await page.waitForTimeout(50);
+    const current = await readIndicator(page, selector);
+    if (current.boxShadow === previous.boxShadow && current.outline === previous.outline) {
+      return current;
+    }
+    previous = current;
+  }
+  return previous;
+};
+
+/**
+ * The indicator's own color: whichever of outline / box-shadow the component
+ * actually uses. Returns null when neither paints anything.
+ */
+const indicatorColor = (styles) => {
+  if (styles.outlineStyle !== 'none' && Number.parseFloat(styles.outlineWidth) > 0) {
+    return parseColor(styles.outlineColor);
+  }
+  if (styles.boxShadow && styles.boxShadow !== 'none') {
+    return parseColor(styles.boxShadow);
+  }
+  return null;
+};
+
+test.describe('focus indicators', () => {
+  // Controls that set `outline: none` and paint their own ring. The editing
+  // surface is deliberately absent: it is a text box whose focus indication is
+  // the caret, not a ring.
+  const CONTROLS = [
+    {
+      name: 'toolbar button',
+      selector: '.editor-toolbar button',
+      open: async () => {},
+    },
+    {
+      name: 'link dialog input',
+      selector: '.form-group input',
+      open: async (page) => {
+        await page.getByRole('button', { name: 'Insert Link' }).click();
+        await expect(page.getByRole('dialog')).toBeVisible();
+      },
+    },
+  ];
+
+  for (const { name, selector, open } of CONTROLS) {
+    test(`${name} shows a focus indicator that differs from its resting state`, async ({
+      page,
+    }) => {
+      await open(page);
+      const control = page.locator(selector).first();
+      const resting = await readIndicator(page, selector);
+
+      await control.focus();
+      await expect(control).toBeFocused();
+      const focused = await settledIndicator(page, selector);
+
+      // Something must visibly change, and it must be a real indicator rather
+      // than only a background/color shift that color-blind users may miss.
+      expect(focused.outline !== resting.outline || focused.boxShadow !== resting.boxShadow).toBe(
+        true,
+      );
+      expect(indicatorColor(focused)).not.toBeNull();
+    });
+
+    test(`${name} focus indicator meets 3:1 contrast (WCAG 2.2 SC 1.4.11)`, async ({ page }) => {
+      await open(page);
+      const control = page.locator(selector).first();
+
+      await control.focus();
+      await expect(control).toBeFocused();
+      const focused = await settledIndicator(page, selector);
+
+      const ring = indicatorColor(focused);
+      expect(ring).not.toBeNull();
+
+      const backdrop = parseColor(focused.backdrop);
+      // A translucent ring is seen as its flattened composite, not its nominal
+      // color — this is where a low-alpha ring fails.
+      const ratio = contrastRatio(flatten(ring, backdrop), backdrop);
+
+      expect(
+        ratio,
+        `focus indicator ${focused.boxShadow || focused.outline} on ${focused.backdrop} is ${ratio.toFixed(2)}:1`,
+      ).toBeGreaterThanOrEqual(3);
+    });
+  }
+});

--- a/src/styles/Editor.css
+++ b/src/styles/Editor.css
@@ -397,7 +397,7 @@ kbd {
   border-color: var(--border-color);
   color: var(--text-color);
   transform: none;
-  box-shadow: 0 0 0 2px rgb(67 97 238 / 30%);
+  box-shadow: 0 0 0 2px var(--focus-color);
 }
 
 /* Universal active state for all toolbar buttons */
@@ -433,9 +433,14 @@ kbd {
   }
 }
 
+/* The ring is the only focus indication (outline is none), so it has to clear
+   3:1 against the toolbar behind it — WCAG 2.2 SC 1.4.11. A translucent ring is
+   seen as its composite over that backdrop, and #4361ee at 30% flattened onto
+   the toolbar's #f8f9fa measured 1.51:1. Solid --focus-color is ~5:1.
+   Regression-tested in e2e/editor.spec.js ("focus indicators"). */
 .editor-toolbar button:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgb(67 97 238 / 30%);
+  box-shadow: 0 0 0 2px var(--focus-color);
 }
 
 /* Button styling */
@@ -548,10 +553,11 @@ kbd {
   transition: var(--transition);
 }
 
+/* As above: at 20% alpha this ring measured 1.32:1 on white. */
 .form-group input:focus {
   outline: none;
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 2px rgb(67 97 238 / 20%);
+  box-shadow: 0 0 0 2px var(--focus-color);
 }
 
 /* Image upload drop zone (rendered only when an upload handler is configured) */
@@ -595,9 +601,14 @@ kbd {
   color: #fff;
 }
 
+/* This button also fills with --primary-color on focus, so the ring is
+   separated from the fill by a white gap; that keeps the indicator visible
+   against both the button and the surface behind it. */
 .upload-button:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgb(67 97 238 / 30%);
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--focus-color);
 }
 
 /* aria-live region for upload progress/errors */

--- a/src/tests/accessibility.test.js
+++ b/src/tests/accessibility.test.js
@@ -122,11 +122,14 @@ const withPageChrome = (component) => (
 );
 
 // Rules that cannot produce meaningful results under jsdom and are therefore
-// excluded here (they ARE covered by the real-browser axe scan in e2e/):
-// - KEYBOARD-01: focus indication is judged from computed CSS; jsdom loads no
-//   stylesheets, so every element looks unstyled
+// excluded here. jsdom loads no stylesheets, so anything judged from computed
+// CSS is unevaluable — every element looks unstyled.
+// - KEYBOARD-01: focus indication. Covered instead by the real-browser focus
+//   indicator tests in e2e/editor.spec.js, which measure the computed
+//   indicator and its contrast in Chromium. (Note: this repo bans axe-core,
+//   so those are Playwright assertions, not an axe scan — see CLAUDE.md.)
 // - NAVIGATION-08: site-level rule (search facility/sitemap) — not applicable
-//   to an embeddable component under test
+//   to an embeddable component under test, and covered nowhere else.
 const JSDOM_INAPPLICABLE_RULES = new Set(['KEYBOARD-01', 'NAVIGATION-08']);
 
 const expectAccessible = async (element) => {


### PR DESCRIPTION
## The stale comment

`src/tests/accessibility.test.js` excluded two rules from its jsdom assertions
with this justification:

> Rules that cannot produce meaningful results under jsdom and are therefore
> excluded here (**they ARE covered by the real-browser axe scan in e2e/**)

That claim was false twice over:

1. There is no axe scan in `e2e/`. `e2e/editor.spec.js` tested editing, the link
   dialog, keyboard reachability, and `initialValue` — no a11y scanning of any kind.
2. axe-core is banned repo-wide per CLAUDE.md, so such a scan must not exist here.

So **KEYBOARD-01 (focus indication) was switched off on the strength of coverage
that did not exist**, and focus visibility was tested by nothing.

## What that was hiding

Closing the gap surfaced a live **WCAG 2.2 SC 1.4.11 (Non-text Contrast)**
failure. Every control that sets `outline: none` supplied its own ring at 20–30%
alpha — which composites almost entirely into the backdrop behind it. Measured in
Chromium, before this change:

| Control | Ring | Backdrop | Contrast | Required |
|---|---|---|---|---|
| Toolbar button | `rgba(67,97,238,0.3)` 2px | `#f8f9fa` | **1.51:1** | ≥ 3:1 |
| Link dialog input | `rgba(67,97,238,0.2)` 2px | `#fff` | **1.32:1** | ≥ 3:1 |

A translucent ring is seen as its flattened composite, not its nominal color —
which is exactly what a contrast check on the declared value would miss.

## The fix

The rings now use the already-declared `--focus-color` **solid**, measuring about
**4.8:1**. No new token, no hue change — same blue, just not washed out.

`.upload-button` needed one extra consideration: it fills with `--primary-color`
on focus, so a solid ring in the same blue would merge into the fill. Its ring is
separated from the button by a white gap (`0 0 0 2px var(--background), 0 0 0 4px
var(--focus-color)`) so it stays visible against both the button and the surface.

**This is a visual change to a published component** — the focus ring is more
prominent than before. That is the point, but it is worth a look before merging.

## The tests

Four Playwright tests in `e2e/editor.spec.js`, using Playwright's own assertions
(no axe — `npm ls axe-core` is empty):

- each control shows an indicator that differs from its resting state, and that
  indicator is a real ring rather than only a background shift;
- the indicator's flattened contrast against its actual backdrop is ≥ 3:1.

They were written against the broken CSS first and **failed with the ratios in the
table above**, then passed after the fix — so they measure the real thing rather
than passing vacuously.

Two details worth flagging for review:

- The tests **poll until the computed style settles**. These controls transition
  `all 0.2s`, so reading on the focus event catches a transparent, zero-spread
  shadow that looks identical to "no indicator at all". This bit during
  development and would have been a confusing flake.
- `.editor-input` is deliberately **excluded**. It is a text box whose focus
  indication is the caret, not a ring; asserting a ring there would be a false
  positive.

The jsdom comment now states what actually covers these rules, and says plainly
that NAVIGATION-08 is covered nowhere.

## Verification

- `npm test` — 171 passed
- `npx playwright test` — 17 passed (13 existing + 4 new)
- eslint / stylelint / prettier clean; `npm ls axe-core` empty