### PR TITLE
fix(a11y): stop the outline panel adding landmarks to the host page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ editing more accessible to all users.
   format as you go; content can also be serialized to Markdown.
 - Live Document Outline: Opt in with `showOutline` for a running list of the
   document's headings, with WCAG-aligned warnings for skipped heading levels and
-  multiple H1s. It is a labelled region rather than a heading, so it never
-  contributes to the host page's heading outline.
+  multiple H1s. It is a labelled list, so it contributes neither a heading nor a
+  landmark to the host page's structure.
 - Word and Character Count: Debounced counts surfaced in a polite live region.
 - Paste Sanitization: Pasted markup from Word or Google Docs is cleaned to
   semantic HTML; Ctrl/Cmd+Shift+V pastes as plain text.
@@ -206,12 +206,14 @@ existing consumers:
   <Editor onContentChange={setContent} showOutline />
   ```
 
-- **Its title is a `<div>`, not an `<h2>`.** The panel is a labelled region
-  (`<section aria-label="Document Outline">`), so an embedded editor no longer
-  injects a heading into the host page's heading hierarchy. Class names
-  (`.editor-outline`, `.editor-outline-title`) are unchanged, but CSS that
-  selected the title by element — `.editor-outline h2` — needs updating to
-  `.editor-outline-title`.
+- **It no longer adds a heading or a landmark to the host page.** The title is a
+  `<div>` rather than an `<h2>`, the panel's `<section>` is unnamed (so it stays
+  generic instead of becoming a `region` landmark), and the heading list is a
+  labelled `<ul>` rather than a `<nav>`. An embedded editor therefore leaves the
+  host page's heading hierarchy and landmark structure alone. Class names
+  (`.editor-outline`, `.editor-outline-title`, `.editor-outline-list`) are
+  unchanged, but CSS or queries that relied on the old elements —
+  `.editor-outline h2`, or a `nav` inside the panel — need updating.
 
 #### TypeScript
 

--- a/src/components/HeadingOutlinePlugin.js
+++ b/src/components/HeadingOutlinePlugin.js
@@ -67,11 +67,16 @@ export function HeadingOutlinePlugin() {
     .filter((entry) => entry.message);
 
   return (
-    <section className="editor-outline" aria-label={t('documentOutline')}>
-      {/* Deliberately not a heading: the panel belongs to a single form control,
-          so contributing an <h2> to the host page's heading outline would
-          misrepresent the page structure (issue #88). The section's aria-label
-          already names the region for assistive technology. */}
+    <section className="editor-outline">
+      {/* This panel belongs to a single form control, so it deliberately adds
+          nothing to the host page's document structure — neither a heading nor
+          a landmark (issue #88).
+
+          The <section> is intentionally left unnamed: HTML maps <section> to
+          role="region" only when it has an accessible name, so omitting the
+          label keeps it a generic element instead of a landmark in the host's
+          landmark list. The outline's accessible name lives on the list below,
+          where it names the thing a screen reader user actually lands in. */}
       <div className="editor-outline-title">{t('documentOutline')}</div>
 
       {/* Non-blocking, accessible warnings: announced politely, prefixed with
@@ -95,26 +100,27 @@ export function HeadingOutlinePlugin() {
       {headings.length === 0 ? (
         <p className="editor-outline-empty">{t('outlineEmpty')}</p>
       ) : (
-        <nav aria-label={t('documentOutline')}>
-          <ul className="editor-outline-list">
-            {headings.map((heading) => (
-              <li
-                key={heading.key}
-                className="editor-outline-item"
-                style={{ marginLeft: `${(headingLevel(heading.tag) - 1) * 16}px` }}
+        /* A plain named list, not a <nav>: this navigates the editor's content,
+           not the host document, so it does not earn a navigation landmark in
+           the page it is embedded in. The label keeps the list identifiable. */
+        <ul className="editor-outline-list" aria-label={t('documentOutline')}>
+          {headings.map((heading) => (
+            <li
+              key={heading.key}
+              className="editor-outline-item"
+              style={{ marginLeft: `${(headingLevel(heading.tag) - 1) * 16}px` }}
+            >
+              <button
+                type="button"
+                className="editor-outline-link"
+                onClick={() => navigateToHeading(heading.key)}
               >
-                <button
-                  type="button"
-                  className="editor-outline-link"
-                  onClick={() => navigateToHeading(heading.key)}
-                >
-                  <span className="editor-outline-tag">{heading.tag.toUpperCase()}</span>{' '}
-                  {heading.text || t('outlineUntitled')}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </nav>
+                <span className="editor-outline-tag">{heading.tag.toUpperCase()}</span>{' '}
+                {heading.text || t('outlineUntitled')}
+              </button>
+            </li>
+          ))}
+        </ul>
       )}
     </section>
   );

--- a/src/tests/HeadingOutlinePlugin.test.js
+++ b/src/tests/HeadingOutlinePlugin.test.js
@@ -51,6 +51,21 @@ const renderWithI18n = (component) => {
   return render(<I18nextProvider i18n={i18n}>{component}</I18nextProvider>);
 };
 
+// Every ARIA landmark role. The panel is embedded inside a single form control,
+// so it must contribute none of them to whatever page hosts the editor.
+const LANDMARK_ROLES = [
+  'banner',
+  'complementary',
+  'contentinfo',
+  'form',
+  'main',
+  'navigation',
+  'region',
+  'search',
+];
+
+const landmarks = () => LANDMARK_ROLES.flatMap((role) => screen.queryAllByRole(role));
+
 const simulateUpdate = (headings) => {
   mockHeadings = headings;
   act(() => {
@@ -72,17 +87,26 @@ describe('HeadingOutlinePlugin', () => {
     expect(screen.getByText(/No headings yet/)).toBeInTheDocument();
   });
 
-  it('is a labelled region and contributes no heading to the host page', () => {
+  it('contributes no heading and no landmark to the host page', () => {
     mockHeadings = [makeHeading('1', 'h1', 'Title')];
 
     renderWithI18n(<HeadingOutlinePlugin />);
 
-    expect(screen.getByRole('region', { name: 'Document Outline' })).toBeInTheDocument();
-    // The panel belongs to a single form control, so its title must not land in
-    // the host page's heading outline (issue #88).
+    // The panel belongs to a single form control, so it must not appear in the
+    // host page's heading outline or its landmark structure (issue #88).
     expect(screen.queryAllByRole('heading')).toHaveLength(0);
-    // ...but the title is still visible as text
+    expect(landmarks()).toHaveLength(0);
+    // ...while the title is still visible, and the outline still identifiable
     expect(screen.getByText('Document Outline')).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: 'Document Outline' })).toBeInTheDocument();
+  });
+
+  it('contributes no landmark in its empty state either', () => {
+    renderWithI18n(<HeadingOutlinePlugin />);
+
+    // The list is absent with no headings, so this covers the other branch:
+    // the panel's landmark count must not depend on the document's content.
+    expect(landmarks()).toHaveLength(0);
   });
 
   it('renders the outline reflecting the document structure', () => {
@@ -94,8 +118,8 @@ describe('HeadingOutlinePlugin', () => {
 
     renderWithI18n(<HeadingOutlinePlugin />);
 
-    const nav = screen.getByRole('navigation', { name: 'Document Outline' });
-    expect(nav).toBeInTheDocument();
+    const outline = screen.getByRole('list', { name: 'Document Outline' });
+    expect(outline).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /H1 Title/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /H2 Section/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /H3 Subsection/ })).toBeInTheDocument();

--- a/src/tests/accessibility.test.js
+++ b/src/tests/accessibility.test.js
@@ -24,11 +24,24 @@ jest.mock('@lexical/react/LexicalComposerContext', () => ({
   useLexicalComposerContext: () => [mockEditor],
 }));
 
+// Root children the mocked editor state exposes. Defaults to empty; a test can
+// populate it to exercise the outline in its non-empty state, where it renders
+// the heading list rather than the empty-state message.
+let mockRootChildren = [];
+
+const makeHeadingNode = (key, tag, text) => ({
+  __isHeading: true,
+  getKey: () => key,
+  getTag: () => tag,
+  getTextContent: () => text,
+  selectStart: jest.fn(),
+});
+
 jest.mock('lexical', () => ({
   $getSelection: jest.fn(() => null),
   $isRangeSelection: jest.fn(() => false),
   $createParagraphNode: jest.fn(() => ({})),
-  $getRoot: jest.fn(() => ({ getChildren: () => [], getTextContent: () => '' })),
+  $getRoot: jest.fn(() => ({ getChildren: () => mockRootChildren, getTextContent: () => '' })),
   KEY_ESCAPE_COMMAND: 'escape',
   COMMAND_PRIORITY_HIGH: 1,
   FORMAT_TEXT_COMMAND: 'format-text',
@@ -48,7 +61,7 @@ jest.mock('@lexical/selection', () => ({ $setBlocksType: jest.fn() }));
 
 jest.mock('@lexical/rich-text', () => ({
   $createHeadingNode: jest.fn(() => ({})),
-  $isHeadingNode: jest.fn(() => false),
+  $isHeadingNode: jest.fn((node) => Boolean(node && node.__isHeading)),
   HeadingNode: class HeadingNode {},
   QuoteNode: class QuoteNode {},
 }));
@@ -136,6 +149,10 @@ const expectAccessible = async (element) => {
 };
 
 describe('accessibility assertions (a11y-assert)', () => {
+  beforeEach(() => {
+    mockRootChildren = [];
+  });
+
   it('toolbar renders without accessibility violations', async () => {
     renderWithI18n(withPageChrome(<ToolbarPlugin showDocs={false} setShowDocs={jest.fn()} />));
 
@@ -162,13 +179,24 @@ describe('accessibility assertions (a11y-assert)', () => {
   // outline panel. Assert it explicitly — the panel sits inside the host's
   // page structure, which is exactly where its markup has to behave (#88).
   it('editor with the outline panel shown has no violations', async () => {
+    // Populate the outline: with no headings it renders its empty-state message
+    // instead of the list, so the assertions below would pass vacuously.
+    mockRootChildren = [
+      makeHeadingNode('1', 'h1', 'Seeded title'),
+      makeHeadingNode('2', 'h2', 'Seeded section'),
+    ];
+
     renderWithI18n(withPageChrome(<Editor onContentChange={jest.fn()} showOutline />));
 
-    expect(screen.getByRole('region', { name: 'Document Outline' })).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: 'Document Outline' })).toBeInTheDocument();
     // The panel must not add to the host page's heading outline: the only
     // heading here is the page's own h1 from withPageChrome.
     expect(screen.getAllByRole('heading')).toHaveLength(1);
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Editor test page');
+    // Nor to its landmark structure: the only landmark is the page's own <main>.
+    expect(screen.getAllByRole('main')).toHaveLength(1);
+    expect(screen.queryAllByRole('region')).toHaveLength(0);
+    expect(screen.queryAllByRole('navigation')).toHaveLength(0);
 
     await expectAccessible(document.body);
   });


### PR DESCRIPTION
> **Stacked on #89.** Base is `feature/88-outline-opt-out`, not `develop`, so the
> diff shows only this change. GitHub retargets it to `develop` automatically
> when #89 merges. It has to be stacked: this edits the same two files as #89
> — including a test that #89 introduces — so basing it on `develop` would mean
> editing an `<h2>` that #89 already replaced, and a guaranteed conflict.

## The problem

Issue #88 was about the outline panel injecting an `<h2>` into the **host page's**
heading hierarchy. #89 fixed that. The reporter's underlying argument — an
embedded widget belonging to a single form control shouldn't shape the host
page's document structure — applies just as well to **landmarks**, and the panel
contributed two:

```jsx
<section className="editor-outline" aria-label="Document Outline">  // role=region
  ...
  <nav aria-label="Document Outline">                               // role=navigation
```

Both named "Document Outline". A screen reader user listing landmarks saw two
entries with identical names, inside a text field, with no way to tell them
apart. Neither was introduced by #89 — the `<section>` and its label predate it.

## The fix

The panel now contributes **zero** landmarks:

- **The `<section>` loses its `aria-label`.** HTML maps `<section>` to
  `role="region"` only when it has an accessible name, so an unnamed one is
  generic — it keeps its styling hook and stops being a landmark.
- **The `<nav>` becomes a plain `<ul>` carrying the label.** The outline
  navigates *the editor's content*, not the host document, so it doesn't earn a
  navigation landmark in the page it's embedded in.

The accessible name moves to the list, where it names what a screen reader user
actually lands in ("Document Outline, list, 3 items"). The title stays visible.
Keyboard behaviour is unchanged — the entries were always buttons and still are.

I considered the other two options in the brief. Keeping the region and dropping
`<nav>` (or naming the two landmarks distinctly) both leave the panel in the
host's landmark list, which is the actual complaint; distinct names would only
make the pollution easier to read, not absent.

## Tests

Asserts zero landmarks across all eight ARIA landmark roles, in **both** the
populated and empty states. The empty state matters and isn't padding: the
`<nav>` only ever rendered when headings existed, so a populated-only test would
have passed vacuously against the region — and it also pins down that the panel's
landmark count doesn't change as you type.

Verified by mutation: restoring the old `aria-label` + `<nav>` fails all four
affected tests, so none of them pass vacuously.

The `@afixt/a11y-assert` case in `src/tests/accessibility.test.js` also covers
this now. That suite mocked `$getRoot()` to return no children, so it only ever
exercised the outline's *empty* state — the list markup was never asserted at
all. Its lexical mock now takes configurable root children, and the outline case
seeds two headings. No axe (`npm ls axe-core` is empty).

README updated: it claimed the panel "is a labelled region", which this makes
false.

## Verification

- `npm test` — 177 passed
- eslint / prettier / markdownlint clean (one pre-existing `max-lines-per-function`
  warning on the component, unchanged in kind)