### PR TITLE
chore(deps): stop pinning @afixt/a11y-assert

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-save-exact=true
 engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-i18next": "^13.0.0"
       },
       "devDependencies": {
-        "@afixt/a11y-assert": "2.1.3",
+        "@afixt/a11y-assert": "^2.1.3",
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.2",
         "@babel/preset-react": "^7.22.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react-i18next": "^13.0.0"
   },
   "devDependencies": {
-    "@afixt/a11y-assert": "2.1.3",
+    "@afixt/a11y-assert": "^2.1.3",
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.2",
     "@babel/preset-react": "^7.22.0",


### PR DESCRIPTION
## Why

We own `@afixt/a11y-assert`, it changes frequently, and we want the latest. An exact pin fights all three. Reproducibility already comes from `package-lock.json`, which pins every transitive dependency with an integrity hash — the exact pin in `package.json` was not providing it.

## Changes

- **`@afixt/a11y-assert`** `2.1.3` → `^2.1.3` (devDependency). 2.1.3 is currently the latest, so nothing resolves differently today.
- **Drop `save-exact=true`** from `.npmrc` — the mechanism that re-pins on every `npm install <pkg>`, so leaving it would silently undo this.

## Scope

Changes what is permitted, not what is installed: the lockfile still resolves 2.1.3, so `npm ci` is unaffected and no code moves.

## Verification

Suite green: **15 suites / 177 tests**.

## Note

Branched from `develop`, not from the `chore/remove-axe-core` branch that was checked out at the time.