### PR TITLE
test(e2e): assert text colour contrast from real computed styles

### DIFF
--- a/e2e/editor.spec.js
+++ b/e2e/editor.spec.js
@@ -271,25 +271,25 @@ const indicatorColor = (styles) => {
 
 /**
  * For each element matching `selector`, read the computed colour, font metrics,
- * and the first opaque background painted behind the text (walking from the
- * element itself up through its ancestors), plus a label for error messages.
+ * and the stack of backgrounds painted behind the text (walking from the
+ * element itself up through its ancestors until the first fully opaque layer),
+ * plus a label for error messages.
  */
 const readTextStyles = (page, selector) =>
   page.evaluate((sel) => {
-    const isOpaque = (background) => {
-      const match = /rgba?\(([^)]+)\)/.exec(background);
-      return match && Number.parseFloat(match[1].split(',')[3] ?? '1') !== 0;
-    };
-
     return [...document.querySelectorAll(sel)].map((element) => {
       const styles = getComputedStyle(element);
 
-      let backdrop = 'rgb(255, 255, 255)';
+      // Every painted layer matters: a translucent background is not the
+      // backdrop itself, it is composited over whatever is beneath it.
+      const backgrounds = [];
       for (let node = element; node; node = node.parentElement) {
         const background = getComputedStyle(node).backgroundColor;
-        if (isOpaque(background)) {
-          backdrop = background;
-          break;
+        const match = /rgba?\(([^)]+)\)/.exec(background);
+        const alpha = match ? Number.parseFloat(match[1].split(',')[3] ?? '1') : 0;
+        if (alpha > 0) {
+          backgrounds.push(background);
+          if (alpha === 1) break;
         }
       }
 
@@ -300,7 +300,7 @@ const readTextStyles = (page, selector) =>
         color: styles.color,
         fontSize: Number.parseFloat(styles.fontSize),
         fontWeight: Number.parseFloat(styles.fontWeight),
-        backdrop,
+        backgrounds,
       };
     });
   }, selector);
@@ -318,14 +318,24 @@ const expectReadableText = async (page, selector) => {
   expect(entries.length, `${selector} matched nothing`).toBeGreaterThan(0);
 
   for (const entry of entries) {
-    const backdrop = parseColor(entry.backdrop);
-    // Translucent text is seen as its composite over the backdrop.
+    // Composite the background stack bottom-up (over white, the page default)
+    // so translucent layers are seen as rendered, not at their nominal colour.
+    const backdrop = entry.backgrounds
+      .reverse()
+      .reduce((below, layer) => flatten(parseColor(layer), below), {
+        r: 255,
+        g: 255,
+        b: 255,
+        a: 1,
+      });
+    // Translucent text is likewise seen as its composite over the backdrop.
     const text = flatten(parseColor(entry.color), backdrop);
     const ratio = contrastRatio(text, backdrop);
+    const backdropLabel = `rgb(${Math.round(backdrop.r)}, ${Math.round(backdrop.g)}, ${Math.round(backdrop.b)})`;
 
     expect(
       ratio,
-      `${entry.label}: ${entry.color} on ${entry.backdrop} is ${ratio.toFixed(2)}:1`,
+      `${entry.label}: ${entry.color} on ${backdropLabel} is ${ratio.toFixed(2)}:1`,
     ).toBeGreaterThanOrEqual(requiredRatio(entry));
   }
 };

--- a/e2e/editor.spec.js
+++ b/e2e/editor.spec.js
@@ -262,6 +262,120 @@ const indicatorColor = (styles) => {
   return null;
 };
 
+// --- Text colour contrast (WCAG 2.2 SC 1.4.3 Contrast (Minimum)) ---
+//
+// Like the focus-indicator checks above, these need real computed styles and
+// therefore a real browser: jsdom loads no stylesheets, so the jsdom rule
+// suite cannot measure contrast at all (issue #84). Each check reads the
+// rendered text colour and the first opaque background painted behind it.
+
+/**
+ * For each element matching `selector`, read the computed colour, font metrics,
+ * and the first opaque background painted behind the text (walking from the
+ * element itself up through its ancestors), plus a label for error messages.
+ */
+const readTextStyles = (page, selector) =>
+  page.evaluate((sel) => {
+    const isOpaque = (background) => {
+      const match = /rgba?\(([^)]+)\)/.exec(background);
+      return match && Number.parseFloat(match[1].split(',')[3] ?? '1') !== 0;
+    };
+
+    return [...document.querySelectorAll(sel)].map((element) => {
+      const styles = getComputedStyle(element);
+
+      let backdrop = 'rgb(255, 255, 255)';
+      for (let node = element; node; node = node.parentElement) {
+        const background = getComputedStyle(node).backgroundColor;
+        if (isOpaque(background)) {
+          backdrop = background;
+          break;
+        }
+      }
+
+      return {
+        label:
+          element.getAttribute('aria-label') ||
+          `${element.tagName.toLowerCase()} "${(element.textContent || '').trim().slice(0, 30)}"`,
+        color: styles.color,
+        fontSize: Number.parseFloat(styles.fontSize),
+        fontWeight: Number.parseFloat(styles.fontWeight),
+        backdrop,
+      };
+    });
+  }, selector);
+
+/**
+ * SC 1.4.3 threshold: large-scale text (24px+, or bold 18.66px+) needs 3:1,
+ * everything else 4.5:1.
+ */
+const requiredRatio = ({ fontSize, fontWeight }) =>
+  fontSize >= 24 || (fontSize >= 18.66 && fontWeight >= 700) ? 3 : 4.5;
+
+/** Assert every element matching `selector` meets its SC 1.4.3 threshold. */
+const expectReadableText = async (page, selector) => {
+  const entries = await readTextStyles(page, selector);
+  expect(entries.length, `${selector} matched nothing`).toBeGreaterThan(0);
+
+  for (const entry of entries) {
+    const backdrop = parseColor(entry.backdrop);
+    // Translucent text is seen as its composite over the backdrop.
+    const text = flatten(parseColor(entry.color), backdrop);
+    const ratio = contrastRatio(text, backdrop);
+
+    expect(
+      ratio,
+      `${entry.label}: ${entry.color} on ${entry.backdrop} is ${ratio.toFixed(2)}:1`,
+    ).toBeGreaterThanOrEqual(requiredRatio(entry));
+  }
+};
+
+test.describe('text colour contrast (WCAG 2.2 SC 1.4.3)', () => {
+  test('every toolbar control has readable text', async ({ page }) => {
+    await expectReadableText(page, '.editor-toolbar button');
+  });
+
+  test('editor content text is readable', async ({ page }) => {
+    await page.locator(EDITOR).click();
+    await page.keyboard.type('Readable body text');
+
+    await expectReadableText(page, `${EDITOR} p`);
+  });
+
+  test('the placeholder is readable', async ({ page }) => {
+    await expectReadableText(page, '.editor-placeholder');
+  });
+
+  test('the word count is readable', async ({ page }) => {
+    await expectReadableText(page, '.editor-word-count');
+  });
+
+  test('code block and inline code text are readable on their backgrounds', async ({ page }) => {
+    const seed = '<p>Uses <code>inline()</code> code</p><pre>const block = true;</pre>';
+    await page.goto(`/?seed=${encodeURIComponent(seed)}`);
+    await expect(page.locator(EDITOR)).toBeVisible();
+
+    await expectReadableText(page, `${EDITOR} .editor-text-code`);
+    await expectReadableText(page, `${EDITOR} .editor-code-block`);
+  });
+
+  test('link text is readable', async ({ page }) => {
+    const seed = '<p><a href="https://example.com">a readable link</a></p>';
+    await page.goto(`/?seed=${encodeURIComponent(seed)}`);
+    await expect(page.locator(EDITOR)).toBeVisible();
+
+    await expectReadableText(page, `${EDITOR} a`);
+  });
+
+  test('dialog labels and inputs are readable', async ({ page }) => {
+    await page.getByRole('button', { name: 'Insert Link' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await expectReadableText(page, '.form-group label');
+    await expectReadableText(page, '.form-group input');
+  });
+});
+
 test.describe('focus indicators', () => {
   // Controls that set `outline: none` and paint their own ring. The editing
   // surface is deliberately absent: it is a text box whose focus indication is

--- a/src/tests/accessibility.test.js
+++ b/src/tests/accessibility.test.js
@@ -139,8 +139,10 @@ const withPageChrome = (component) => (
 // CSS is unevaluable — every element looks unstyled.
 // - KEYBOARD-01: focus indication. Covered instead by the real-browser focus
 //   indicator tests in e2e/editor.spec.js, which measure the computed
-//   indicator and its contrast in Chromium. (Note: this repo bans axe-core,
-//   so those are Playwright assertions, not an axe scan — see CLAUDE.md.)
+//   indicator and its contrast in Chromium. Text colour contrast (SC 1.4.3)
+//   is likewise unevaluable here and covered by the real-browser contrast
+//   tests in the same file. (Note: this repo bans axe-core, so those are
+//   Playwright assertions, not an axe scan — see CLAUDE.md.)
 // - NAVIGATION-08: site-level rule (search facility/sitemap) — not applicable
 //   to an embeddable component under test, and covered nowhere else.
 const JSDOM_INAPPLICABLE_RULES = new Set(['KEYBOARD-01', 'NAVIGATION-08']);


### PR DESCRIPTION
## Summary

Closes #84 — restores the real-browser accessibility coverage lost when PR #79 removed the axe scan, via **option 2** from the issue (targeted Playwright assertions), which the issue calls a reasonable stopgap. Option 1 (a live-page Playwright mode for `@afixt/a11y-assert`) remains the long-term fix and belongs in that package's repo.

## What's here

A new `text colour contrast (WCAG 2.2 SC 1.4.3)` suite in `e2e/editor.spec.js`. Each check runs in real Chromium and:

- reads the rendered text colour and walks up from the element for the first opaque background actually painted behind it;
- composites translucent colours before measuring;
- applies the size-aware threshold (4.5:1 normal, 3:1 for large-scale text).

Covered surfaces: every toolbar control, editor content text, the placeholder, the word count, code blocks and inline code on their tinted backgrounds, link text, and the link dialog's labels and inputs.

The measurement helpers are the same hand-rolled WCAG math the focus-indicator suite (PR #90) already uses — no new dependencies, no axe-core.

## Acceptance criteria from #84

- ✅ E2E suite asserts colour contrast **and** visible focus indication on the toolbar and content area from real computed styles (focus indication landed in PR #90; this adds contrast).
- ✅ `npm run security:banned-deps` passes — no dependency changes at all.

## Verification

- `npx playwright test` — 24/24 pass (7 new)
- Negative test: injecting `color: #ccc` on the word count measures 1.61:1 through the same pipeline, so a regression will fail loudly.
- jsdom suite comment updated to note SC 1.4.3 is covered by these tests.
- `npm test` (jsdom) still 176/176; lint 0 errors (one new `max-lines` warning on the spec, structural-warning tier).