### PR TITLE
fix(deps): bump vite past GHSA-v6wh-96g9-6wx3 and GHSA-fx2h-pf6j-xcff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "stylelint-declaration-strict-value": "1.11.1",
         "ts-api-utils": "2.5.0",
         "typescript": "5.9.3",
-        "vite": "^7.3.2"
+        "vite": "^7.3.5"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -22674,12 +22674,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "stylelint-declaration-strict-value": "1.11.1",
     "ts-api-utils": "2.5.0",
     "typescript": "5.9.3",
-    "vite": "^7.3.2"
+    "vite": "^7.3.5"
   },
   "size-limit": [
     {


### PR DESCRIPTION
Fixes #100

## What changed

`npm update vite` — one lockfile entry, **7.3.2 → 7.3.6** — plus the declared range `^7.3.2 → ^7.3.5`.

## Two advisories, not one

The issue names GHSA-v6wh-96g9-6wx3 (CVSS 5.5). `osv-scanner` reports a second one against the same lockfile entry with the same fixed version:

| Advisory | CVSS | Fixed in |
|---|---|---|
| GHSA-v6wh-96g9-6wx3 | 5.5 | 7.3.5 |
| **GHSA-fx2h-pf6j-xcff** | **8.2** | 7.3.5 |

One bump clears both. OSV goes **31 packages / 73 vulnerabilities → 30 / 71**, and the two that left are exactly these.

## Why the range floor moves too

The issue calls for a lockfile-only bump, and today that would be sufficient — `^7.3.2` always resolves to the newest match, which is 7.3.6. The floor is raised anyway because that reasoning depends on resolution *reaching the top of the range*, and #99 introduces `min-release-age=7`, whose entire purpose is to hold resolution back from the newest releases. A range whose bottom is a known-vulnerable version is a latent way back in whenever the lockfile is regenerated. `^7.3.5` makes the range itself express the constraint. (All three versions are well outside the seven-day window — 7.3.5 is 73 days old, 7.3.6 is 50 — so the cooldown and this bump do not interact today.)

## Deliberately surgical

`npm update vite` touched **one** lockfile entry and nothing else — verified by listing every changed `node_modules/*` key in the diff.

That restraint is the point. A broader refresh drags `@afixt/afixt-tests` from the locked 1.28.4 to 1.35.x, whose AAA advisory rule `TIMEOUTS-04` fails `src/tests/accessibility.test.js` — filed as **#101**. Confirmed after the bump that `@afixt/afixt-tests` (1.28.4) and `@afixt/a11y-assert` (2.1.3) are still on their locked versions, in both the lockfile and `node_modules`.

## Local verification

Actions minutes are exhausted, so this is the source of truth rather than `gh pr checks`.

| Check | Result |
|---|---|
| `npm run security:osv` | ✅ both vite advisories gone |
| `npm run check` (lint, lint:css, lint:md, format:check, types:check) | ✅ exit 0 |
| `npm test` | ✅ **176/176, 15 suites** (185 on #99's branch, which adds the 9 action-pin tests) |
| `npm run build` (rollup) | ✅ |
| `npm run test:dist` | ✅ 6/6 against the real ESM + CJS artifacts |
| **`npm run build:demo`** (vite itself) | ✅ built in 3.21s — this is the code path the bump actually changes |
| `npm run dupes:ci` | ✅ 0 clones |
| `npm run size` | ✅ 100.57 kB, limit 105 kB |
| `npm run license:check` | ✅ MIT only (35) |
| `npm run security:audit` | ✅ 0 vulnerabilities |
| `npm run security:banned-deps` | ✅ none in tree |
| `npm run security:secrets` | ✅ 0 (pre-push hook) |

`build:demo` is called out because a lockfile bump is easy to declare safe from a green unit suite that never loads the bumped tool. vite builds the demo; that build was exercised.

Ready to merge pending CI restoration.
