### PR TITLE
test(usecases): cover the eight editor features that had no use-case coverage

### DIFF
--- a/usecases/11-image-alt-text-required.uc.yaml
+++ b/usecases/11-image-alt-text-required.uc.yaml
@@ -1,0 +1,57 @@
+id: editor-image-alt-text-required
+title: "Insert An Image, Which Cannot Be Inserted Without Alt Text"
+type: positive
+description: "Verify that the image dialog refuses to insert until the author supplies alt
+  text, that the alt field is marked required and has a programmatic hint, and that a
+  described image is inserted with its accessible name."
+
+preconditions:
+  - "The demo app is running (npm start)"
+  - "The editor is empty"
+
+start_location: "http://localhost:4001"
+
+expected_result: "Insert is disabled while alt text is missing, becomes enabled once alt
+  text is entered, and the inserted image exposes that alt text as its accessible name"
+
+data:
+  image_url: "https://REPLACE_ME.example.com/photo.png"
+  alt_text: "A red bicycle leaning against a brick wall"
+
+steps:
+  - locate: button "Insert Image"
+  - focus: button "Insert Image"
+  - activate: button "Insert Image"
+
+  - locate: dialog "Insert Image"
+  - verify: dialog "Insert Image" attribute "aria-modal" is "true"
+
+  # Audit the dialog before interacting with it
+  - audit: dialog "Insert Image" level "AA"
+
+  # Both fields advertise that they are required, and the alt field points at
+  # its hint. This is the wiring that makes the requirement perceivable rather
+  # than merely enforced.
+  - locate: field "URL"
+  - verify: field "URL" attribute "aria-required" is "true"
+  - locate: field "Alt Text"
+  - verify: field "Alt Text" attribute "aria-required" is "true"
+  - verify: field "Alt Text" attribute "aria-describedby" present
+
+  # A URL alone is not enough — the gate is alt text.
+  - focus: field "URL"
+  - enter: field "URL" value "{{ image_url }}"
+  - verify: disabled button "Insert"
+
+  - locate: field "Alt Text"
+  - focus: field "Alt Text"
+  - enter: field "Alt Text" value "{{ alt_text }}"
+  - verify: enabled button "Insert"
+
+  - locate: button "Insert"
+  - focus: button "Insert"
+  - activate: button "Insert"
+
+  # The alt text becomes the image's accessible name.
+  - locate: image "{{ alt_text }}"
+  - audit: page level "AA"

--- a/usecases/12-image-decorative-optout.uc.yaml
+++ b/usecases/12-image-decorative-optout.uc.yaml
@@ -1,0 +1,56 @@
+id: editor-image-decorative-optout
+title: "Mark An Image Decorative Instead Of Describing It"
+type: positive
+description: "Verify the explicit decorative opt-out: checking it releases the alt-text
+  requirement, disables the now-meaningless alt field, and inserts the image with an empty
+  alt attribute rather than a fabricated description."
+
+preconditions:
+  - "The demo app is running (npm start)"
+  - "The editor is empty"
+  - "The page carries no other images — the final step asserts the image count is zero,
+    which is how a correctly hidden decorative image presents in the accessibility tree"
+
+start_location: "http://localhost:4001"
+
+expected_result: 'With the decorative checkbox checked, Insert becomes enabled with no alt
+  text, the alt field is disabled, and the image is inserted with alt=""'
+
+data:
+  image_url: "https://REPLACE_ME.example.com/divider.png"
+  decorative_label: "This image is decorative (no alt text needed)"
+
+steps:
+  - locate: button "Insert Image"
+  - focus: button "Insert Image"
+  - activate: button "Insert Image"
+
+  - locate: dialog "Insert Image"
+
+  - locate: field "URL"
+  - focus: field "URL"
+  - enter: field "URL" value "{{ image_url }}"
+
+  # Insert stays shut while the image is neither described nor declared decorative.
+  - verify: disabled button "Insert"
+
+  - locate: checkbox "{{ decorative_label }}"
+  - focus: checkbox "{{ decorative_label }}"
+  - select: checkbox "{{ decorative_label }}"
+  - verify: checked checkbox "{{ decorative_label }}"
+
+  # The opt-out is a real state change, not a label: the alt field goes disabled
+  # and stops claiming to be required.
+  - verify: disabled field "Alt Text"
+  - verify: field "Alt Text" attribute "aria-required" is "false"
+  - verify: enabled button "Insert"
+
+  - locate: button "Insert"
+  - focus: button "Insert"
+  - activate: button "Insert"
+
+  # A decorative image must be hidden from assistive technology, so it must NOT
+  # appear as a named image in the accessibility tree.
+  - verify: count image is 0
+
+  - audit: page level "AA"

--- a/usecases/13-table-insert.uc.yaml
+++ b/usecases/13-table-insert.uc.yaml
@@ -1,0 +1,54 @@
+id: editor-table-insert
+title: "Insert A Data Table With A Header Row"
+type: positive
+description: "Verify that a table can be inserted from the toolbar dialog with a header row,
+  and that the result exposes real column headers to assistive technology rather than a grid
+  of visually bold cells."
+
+preconditions:
+  - "The demo app is running (npm start)"
+  - "The editor is empty"
+
+start_location: "http://localhost:4001"
+
+expected_result: "A table is inserted whose first row is exposed as column headers in the
+  accessibility tree"
+
+data:
+  rows: "3"
+  columns: "2"
+  header_row_label: "Include header row"
+
+steps:
+  - locate: button "Insert Table"
+  - focus: button "Insert Table"
+  - activate: button "Insert Table"
+
+  - locate: dialog "Insert Table"
+  - verify: dialog "Insert Table" attribute "aria-modal" is "true"
+
+  # Audit the dialog before interacting with it
+  - audit: dialog "Insert Table" level "AA"
+
+  - locate: field "Rows"
+  - focus: field "Rows"
+  - enter: field "Rows" value "{{ rows }}"
+
+  - locate: field "Columns"
+  - focus: field "Columns"
+  - enter: field "Columns" value "{{ columns }}"
+
+  - locate: checkbox "{{ header_row_label }}"
+  - focus: checkbox "{{ header_row_label }}"
+  - verify: checked checkbox "{{ header_row_label }}"
+
+  - locate: button "Insert"
+  - focus: button "Insert"
+  - activate: button "Insert"
+
+  # The assertion that matters. A table whose header row is only visually
+  # distinct exposes zero columnheaders, so this fails exactly when the
+  # semantics regress — which a screenshot never would.
+  - verify: count columnheader is {{ columns }}
+
+  - audit: page level "AA"

--- a/usecases/14-block-content.uc.yaml
+++ b/usecases/14-block-content.uc.yaml
@@ -1,0 +1,61 @@
+id: editor-block-content
+title: "Apply Blockquote, Code Block, Inline Code And Horizontal Rule"
+type: positive
+description: "Verify the block-level and inline-code controls that no other use case covers:
+  blockquote, code block, inline code, clear formatting, and horizontal rule — each through
+  the toolbar, asserting toggle state through aria-pressed."
+
+preconditions:
+  - "The demo app is running (npm start)"
+  - "The editor is empty"
+
+start_location: "http://localhost:4001"
+
+expected_result: "Each control reports its state through aria-pressed, and the resulting
+  document passes an automated WCAG audit"
+
+steps:
+  - locate: field "Editor content"
+  - focus: field "Editor content"
+  - keyboard: "A quoted passage"
+  - keyboard: "ControlOrMeta+a"
+
+  # Blockquote — a toggle, so it must say so.
+  - locate: button "Blockquote"
+  - focus: button "Blockquote"
+  - verify: button "Blockquote" attribute "aria-pressed" is "false"
+  - activate: button "Blockquote"
+  - verify: button "Blockquote" attribute "aria-pressed" is "true"
+
+  # Inline code on a fresh selection.
+  - focus: field "Editor content"
+  - keyboard: "ControlOrMeta+a"
+  - locate: button "Inline Code"
+  - focus: button "Inline Code"
+  - activate: button "Inline Code"
+  - verify: button "Inline Code" attribute "aria-pressed" is "true"
+
+  # Clear formatting is an action, not a toggle. Its effect is observable on
+  # the control it resets, which is the assertion worth making: inline code
+  # must report itself as no longer applied.
+  - locate: button "Clear Formatting"
+  - focus: button "Clear Formatting"
+  - activate: button "Clear Formatting"
+  - verify: button "Inline Code" attribute "aria-pressed" is "false"
+
+  # Code block.
+  - focus: field "Editor content"
+  - keyboard: "ControlOrMeta+a"
+  - locate: button "Code Block"
+  - focus: button "Code Block"
+  - activate: button "Code Block"
+  - verify: button "Code Block" attribute "aria-pressed" is "true"
+
+  # Horizontal rule — an insertion, not a toggle.
+  - focus: field "Editor content"
+  - keyboard: "End"
+  - locate: button "Insert Horizontal Rule"
+  - focus: button "Insert Horizontal Rule"
+  - activate: button "Insert Horizontal Rule"
+
+  - audit: page level "AA"

--- a/usecases/15-toolbar-roving-focus.uc.yaml
+++ b/usecases/15-toolbar-roving-focus.uc.yaml
@@ -1,0 +1,42 @@
+id: editor-toolbar-roving-focus
+title: "Traverse The Toolbar As A Single Tab Stop With Roving Focus"
+type: positive
+description: "Verify the toolbar implements the WAI-ARIA toolbar pattern: one tab stop,
+  arrow keys move focus between controls, and Home/End jump to the first and last control.
+  Without this, reaching the last toolbar button costs a keyboard user dozens of tabs."
+
+preconditions:
+  - "The demo app is running (npm start)"
+
+start_location: "http://localhost:4001"
+
+expected_result: "Focus enters the toolbar once, moves with arrow keys, and Home/End reach
+  the first and last controls"
+
+steps:
+  # The toolbar is a named toolbar in the accessibility tree, not an unlabelled
+  # div of buttons.
+  - locate: region "Editor Toolbar"
+
+  - locate: button "Undo"
+  - focus: button "Undo"
+  - verify: focus button "Undo"
+
+  # Arrow keys move focus within the toolbar.
+  - keyboard: "ArrowRight"
+  - verify: focus button "Redo"
+  - keyboard: "ArrowLeft"
+  - verify: focus button "Undo"
+
+  # End and Home reach the extremes without traversing everything between.
+  - keyboard: "End"
+  - verify: focus button "Show Help"
+  - keyboard: "Home"
+  - verify: focus button "Undo"
+
+  # The single-tab-stop half of the pattern: one Tab from the first control
+  # leaves the toolbar entirely rather than landing on the second button.
+  - keyboard: "Tab"
+  - verify: focus field "Editor content"
+
+  - audit: page level "AA"

--- a/usecases/16-word-count-live-region.uc.yaml
+++ b/usecases/16-word-count-live-region.uc.yaml
@@ -1,0 +1,33 @@
+id: editor-word-count-live-region
+title: "Announce Word And Character Counts Politely"
+type: positive
+description: "Verify the word/character counter is a polite live region, so a screen-reader
+  user learns the count changed without the announcement interrupting their typing."
+
+preconditions:
+  - "The demo app is running (npm start)"
+  - "The editor is empty"
+
+start_location: "http://localhost:4001"
+
+expected_result: "The counter updates to reflect typed content and is announced politely"
+
+data:
+  sample_text: "Four words go here"
+  expected_count: "4 words"
+
+steps:
+  - locate: field "Editor content"
+  - focus: field "Editor content"
+  - keyboard: "{{ sample_text }}"
+
+  # The counts are debounced, so give the region time to settle before
+  # asserting on it.
+  - wait_for: text "{{ expected_count }}"
+  - verify: live_region "{{ expected_count }}"
+
+  # And it must actually reach the screen reader. `polite` is the point: an
+  # assertive counter would interrupt every few keystrokes.
+  - sr_says: '"{{ expected_count }}" within 5s'
+
+  - audit: page level "AA"

--- a/usecases/17-document-outline-warnings.uc.yaml
+++ b/usecases/17-document-outline-warnings.uc.yaml
@@ -1,0 +1,50 @@
+id: editor-document-outline-warnings
+title: "Warn Politely About A Skipped Heading Level In The Outline"
+type: positive
+description: "Verify the live document outline lists the document's headings as a named list
+  and reports a skipped heading level as a politely announced warning that is not conveyed by
+  colour alone."
+
+preconditions:
+  - "The demo app is running (npm start) — the demo mounts the editor with showOutline"
+  - "The editor is empty"
+
+start_location: "http://localhost:4001"
+
+expected_result: "The outline lists both headings, and skipping from H1 to H3 produces a
+  politely announced warning naming the levels involved"
+
+data:
+  h1_text: "Chapter One"
+  h3_text: "A Subsection"
+  skip_warning: "Heading level skipped: h1 is followed by h3"
+
+steps:
+  - locate: field "Editor content"
+  - focus: field "Editor content"
+
+  # An H1 followed directly by an H3 — the exact defect the outline exists to
+  # surface while it is still cheap to fix.
+  - keyboard: "{{ h1_text }}"
+  - keyboard: "ControlOrMeta+Alt+1"
+  - keyboard: "Enter"
+  - keyboard: "{{ h3_text }}"
+  - keyboard: "ControlOrMeta+Alt+3"
+
+  # The outline is a named list, so a screen reader user can identify what they
+  # have landed in. It is deliberately not a landmark — this panel belongs to
+  # one form control and must not restructure the host page.
+  - locate: list "Document Outline"
+  - verify: count navigation is 0
+
+  # Both headings appear as activatable outline entries.
+  - locate: button "H1 {{ h1_text }}"
+  - locate: button "H3 {{ h3_text }}"
+
+  # The warning is announced politely rather than interrupting typing, and it
+  # carries a text prefix so it does not rely on the colour of the row.
+  - wait_for: text "{{ skip_warning }}"
+  - verify: 'live_region "Warning: {{ skip_warning }}"'
+  - sr_says: '"{{ skip_warning }}" within 5s'
+
+  - audit: page level "AA"

--- a/usecases/18-markdown-shortcuts.uc.yaml
+++ b/usecases/18-markdown-shortcuts.uc.yaml
@@ -1,0 +1,50 @@
+id: editor-markdown-shortcuts
+title: "Format As You Type With Markdown Shortcuts"
+type: positive
+description: "Verify the markdown shortcut path produces the same real semantics as the
+  toolbar: typing '# ' yields a level-1 heading, '- ' yields a list, and '> ' yields a
+  blockquote — not merely text that looks like them."
+
+preconditions:
+  - "The demo app is running (npm start)"
+  - "The editor is empty"
+
+start_location: "http://localhost:4001"
+
+expected_result: "Markdown shortcuts produce headings, lists and blockquotes that appear in
+  the accessibility tree with the correct roles and levels"
+
+data:
+  heading_text: "Typed As Markdown"
+  list_item_text: "First bullet"
+
+steps:
+  - locate: field "Editor content"
+  - focus: field "Editor content"
+
+  # '# ' must produce a real heading, not 18px bold text. A markdown shortcut
+  # that only restyles is an accessibility regression that looks correct in a
+  # screenshot.
+  - keyboard: "# {{ heading_text }}"
+  - verify: heading "{{ heading_text }}"
+  - locate: heading "{{ heading_text }}"
+
+  # The toolbar must agree — the control reflects the state the shortcut
+  # produced, so keyboard and toolbar cannot drift apart.
+  - verify: button "H1" attribute "aria-pressed" is "true"
+
+  # '- ' must produce a real list.
+  - focus: field "Editor content"
+  - keyboard: "Enter"
+  - keyboard: "- {{ list_item_text }}"
+  - verify: count listitem is 1
+  - verify: button "Bullet List" attribute "aria-pressed" is "true"
+
+  # '> ' must produce a real blockquote.
+  - focus: field "Editor content"
+  - keyboard: "Enter"
+  - keyboard: "Enter"
+  - keyboard: "> A quoted line"
+  - verify: button "Blockquote" attribute "aria-pressed" is "true"
+
+  - audit: page level "AA"

--- a/usecases/README.md
+++ b/usecases/README.md
@@ -20,9 +20,41 @@ accessibility finding.
 | Help overlay open/close, button + Ctrl/Cmd+D  | `08-help-overlay.uc.yaml`               |
 | Undo / redo from the keyboard                 | `09-undo-redo.uc.yaml`                  |
 | Automated WCAG audits (page + dialog scoped)  | `10-page-audit.uc.yaml`                 |
+| Image insert, alt text required               | `11-image-alt-text-required.uc.yaml`    |
+| Image marked decorative (`alt=""`) instead    | `12-image-decorative-optout.uc.yaml`    |
+| Table insert with a real header row           | `13-table-insert.uc.yaml`               |
+| Blockquote, code block, inline code, HR       | `14-block-content.uc.yaml`              |
+| Toolbar roving tabindex, arrows, Home/End     | `15-toolbar-roving-focus.uc.yaml`       |
+| Word / character count live region            | `16-word-count-live-region.uc.yaml`     |
+| Document outline + skipped-heading warning    | `17-document-outline-warnings.uc.yaml`  |
+| Markdown shortcuts (`#`, `-`, `>`)            | `18-markdown-shortcuts.uc.yaml`         |
 
 Toolbar toggle state is asserted through `aria-pressed` so each use case also
 verifies the control semantics, not just the visual result.
+
+Several of these assert on the accessibility tree rather than on appearance,
+which is the point of writing them here rather than as unit tests:
+
+- `12` asserts the decorative image count is **zero** — that is how `alt=""`
+  plus `role="presentation"` presents to assistive technology.
+- `13` asserts the `columnheader` count, so a header row that is only visually
+  bold fails.
+- `17` asserts the outline is a named list and contributes **no** landmark, so
+  the panel cannot start restructuring the host page.
+- `18` asserts markdown shortcuts produce real headings and lists, not text that
+  merely looks like them.
+
+## Not covered, and why
+
+**Paste sanitization and paste-as-plain-text (`Ctrl/Cmd+Shift+V`).** The editor
+sanitizes markup pasted from Word and Google Docs, and `Ctrl/Cmd+Shift+V` forces
+a plain-text paste. Neither can be expressed here: the `@afixt/usecase-runner`
+DSL (v1.5.1) has no clipboard or paste verb, and faking one through raw
+`keyboard:` steps would not populate `clipboardData`, so the template would pass
+without ever exercising `PastePlugin`. A template that cannot fail is worse than
+none. This is a candidate for an upstream `paste:` keyword rather than a
+workaround — see the tracking issue. Paste behaviour is covered by the Jest
+suite in the meantime.
 
 ## Accessible names these depend on
 

--- a/usecases/README.md
+++ b/usecases/README.md
@@ -53,8 +53,8 @@ DSL (v1.5.1) has no clipboard or paste verb, and faking one through raw
 `keyboard:` steps would not populate `clipboardData`, so the template would pass
 without ever exercising `PastePlugin`. A template that cannot fail is worse than
 none. This is a candidate for an upstream `paste:` keyword rather than a
-workaround — see the tracking issue. Paste behaviour is covered by the Jest
-suite in the meantime.
+workaround — see #104. Paste behaviour is covered by the Jest suite in the
+meantime.
 
 ## Accessible names these depend on
 
@@ -62,12 +62,24 @@ Use cases address controls by accessible name, all defined in
 `src/utils/i18n.js`:
 
 - `Editor content` — the editor surface's `aria-label` (`editorContent`).
+- `Editor Toolbar` — the toolbar's `aria-label` (`editorToolbar`).
 - `Bullet List`, `Numbered List`, `Show Help` — `bulletList` / `numberedList` /
   `showHelp`.
 - `Insert Link` — the link button's `aria-label` (`insertLink`).
+- `Undo`, `Redo`, `Blockquote`, `Inline Code`, `Code Block`, `Clear Formatting`,
+  `Insert Horizontal Rule`, `Insert Image`, `Insert Table` — the remaining
+  toolbar `aria-label`s.
+- `H1`–`H6` — the heading buttons are labelled with the short form, **not**
+  "Heading 1". Getting this wrong produces a template that validates cleanly and
+  then fails to locate anything at run time.
+- `Alt Text`, `URL`, `Rows`, `Columns` — dialog field labels.
+- `Include header row`, `This image is decorative (no alt text needed)` — the
+  two dialog checkboxes, addressed by their full visible label.
+- `Document Outline` — the outline list's `aria-label`.
 
-These all resolve on `develop` today. A use case that fails to locate one of
-these controls therefore means the accessible name has regressed.
+These all resolve on `develop` today, verified against `src/utils/i18n.js`. A
+use case that fails to locate one of these controls therefore means the
+accessible name has regressed.
 
 ## Running them
 
@@ -89,4 +101,5 @@ npx usecase-runner validate usecases/*.uc.yaml
 npx usecase-runner generate usecases/*.uc.yaml --outdir ./tests/generated --run
 ```
 
-All ten use cases in this directory pass `npx usecase-runner validate` (v1.4.1).
+All eighteen use cases in this directory pass `npx usecase-runner validate`
+(v1.5.1).


### PR DESCRIPTION
Fixes #104

## What changed

`usecases/` goes from **10 templates to 18**. The eight new ones cover features that had no use-case coverage at all, audited against the feature list in `README.md` and against `src/components/`.

| New template | What it pins |
|---|---|
| `11-image-alt-text-required` | Insert stays **disabled** until alt text exists; `aria-required` on both fields; `aria-describedby` on the alt field; the alt text becomes the image's accessible name |
| `12-image-decorative-optout` | Checking "decorative" enables Insert with no alt text, disables the alt field, and drops `aria-required` — then the image is **absent from the accessibility tree** |
| `13-table-insert` | `columnheader` count matches the column count |
| `14-block-content` | Blockquote, inline code, clear formatting, code block, horizontal rule — via `aria-pressed` |
| `15-toolbar-roving-focus` | One tab stop, arrow keys, Home/End, and Tab **leaving** the toolbar |
| `16-word-count-live-region` | The counter is a polite live region and actually reaches the screen reader |
| `17-document-outline-warnings` | Named list, **zero** landmarks, skipped-level warning announced politely with a text prefix |
| `18-markdown-shortcuts` | `#`, `-`, `>` produce real headings/lists/quotes, and the toolbar's state agrees |

## Assertions chosen to fail for the right reason

The templates deliberately assert on the accessibility tree wherever it can disagree with appearance — that is the whole reason these live here rather than in the Jest suite:

- **12** asserts `count image is 0`. A decorative image is correct precisely when it is *invisible* to assistive technology (`alt=""` + `role="presentation"`, per `ImageNode`). An implementation that helpfully filled in alt text would fail this.
- **13** asserts `count columnheader is {{ columns }}`. A header row that is only visually bold yields zero columnheaders.
- **17** asserts `count navigation is 0`, pinning the deliberate decision in #88 that the outline panel must not add a landmark to the host page. Nothing pinned that before.
- **15** asserts Tab from the first control lands on the editor, not the second button — the half of the roving-tabindex pattern that a per-button focus test would miss.

## Verification

Actions minutes are exhausted, so local runs are the source of truth.

| Check | Result |
|---|---|
| `usecase-runner validate usecases/` | ✅ **18/18 valid** (runner v1.5.1) |
| `npm run check` (lint, lint:css, lint:md, format:check, types:check) | ✅ exit 0 |
| `npm test` | ✅ 176/176, 15 suites |
| `npm run security:banned-deps` | ✅ none in tree |
| `npm run security:secrets` | ✅ 0 (pre-commit hook, every commit) |

Two authoring bugs that validation alone did **not** catch, found by cross-checking every accessible name against `src/utils/i18n.js`:

- The heading buttons are labelled `H1`–`H6`, not `Heading 1`. `18-markdown-shortcuts` had `button "Heading 1"` and validated perfectly clean — it would simply have located nothing at run time. Fixed, and the README now lists every name the templates depend on so the next author doesn't repeat it.
- `verify: ... attribute "aria-pressed" absent` is not a valid predicate (the set is `is|present|starts_with|matches|references_existing_id|within_range_of`). Replaced with an assertion on the observable effect instead of the absence of an attribute.

Both are the reason "it validates" is not the same as "it works", and neither would have shown up until someone ran the generated Playwright suite.

## Deliberately not covered

**Paste sanitization and `Ctrl/Cmd+Shift+V`.** `usecase-runner` 1.5.1 has no clipboard or paste verb — `grep -n "paste\|clipboard"` over its README returns nothing. Raw `keyboard:` steps do not populate `clipboardData`, so `PastePlugin` would never execute and the template would pass unconditionally. A template that cannot fail is worse than none, and per `../audit-usecases/CLAUDE.md` a missing DSL capability is an upstream candidate rather than a template hack. Recorded in `usecases/README.md` and in #104; Jest covers paste in the meantime.

## Note on running these

The templates are validated, not executed, here: running them needs the demo app on `http://localhost:4001` plus a Playwright browser, and `npx @afixt/usecase-runner` currently 404s against the private `@afixt` scope while the npm token is dead (AFixt/hint-afixt#51). Validation was run against the local checkout of the runner at `../../usecase-runner` (v1.5.1). Once the token is restored, `usecase-runner generate --run` is the next step and may surface run-time naming issues that validation cannot.

Ready to merge pending CI restoration.
