### PR TITLE
ci: drop CodeQL and the SARIF upload, which cannot pass with Code Security off

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -87,23 +87,25 @@ jobs:
           path: npm-audit-results.json
           retention-days: 30
 
-  # CodeQL Analysis (SAST)
-  codeql:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
-        with:
-          languages: javascript-typescript
-          queries: security-and-quality
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
-        with:
-          category: "/language:javascript-typescript"
+  # There is deliberately no CodeQL job here (#102).
+  #
+  # CodeQL cannot store its results unless GitHub Code Security is enabled for
+  # the repository, and that is a settings-level decision that has been made
+  # the other way: Code Security stays off, with SARIF kept as a build
+  # artifact instead. The job that used to live here analysed the source
+  # successfully on every run and then failed at the upload step with
+  # "Code Security must be enabled for this repository", discarding the SARIF
+  # it had just produced.
+  #
+  # That is the exact shape of failure this repository's CI policy exists to
+  # remove: a check that cannot pass, carries no signal, and trains people to
+  # skim past a red workflow. Unlike the CodeQL job, semgrep
+  # (`npm run security:semgrep` — 110 rules over 97 files) runs locally and in
+  # `check:all`, and fails the build on findings.
+  #
+  # The same constraint rules out every SARIF upload, not just CodeQL's — see
+  # the OWASP job below, which keeps its report as an artifact. If Code
+  # Security is ever enabled, both can come back together.
 
   # OWASP Dependency Check (comprehensive - weekly only)
   owasp-dependency-check:
@@ -149,11 +151,11 @@ jobs:
           path: reports/
           retention-days: 90
 
-      - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
-        with:
-          sarif_file: reports/dependency-check-report.sarif
-        if: always()
+      # The SARIF is deliberately NOT uploaded to GitHub Security (#102). That
+      # endpoint needs Code Security enabled, which it is not, so the upload
+      # step failed on every run while the artifact above — which contains the
+      # same SARIF — succeeded. Download the artifact and open
+      # reports/dependency-check-report.sarif in any SARIF viewer.
 
   # License compliance check
   license-check:


### PR DESCRIPTION
Fixes #102

## What changed

Two steps deleted from `security.yml`, both replaced by comments recording why they are gone:

| Removed | Trigger | Failure |
|---|---|---|
| `codeql` job (`init` + `analyze`) | **every push and PR** | `analyze` uploads to the Code Scanning API as its last step → `Code Security must be enabled for this repository` |
| `Upload SARIF to GitHub Security` in the OWASP job | `workflow_dispatch`, `if: always()` | same endpoint, same failure — and it ran even when the scan itself had failed |

Both require GitHub Code Security, which is off by decision in favour of artifact-based SARIF.

## Why remove rather than leave red

A check that *cannot* pass carries no signal and trains people to skim past a red workflow — the same failure mode #98 was filed to remove, arriving by a different route. The CodeQL job was the worse of the two because it was not dispatch-gated, so it reddened every pull request. It also did the analysis work on every run and then threw the result away at the upload.

Nothing is lost:

- **SAST coverage** stays with semgrep (`npm run security:semgrep` — 110 rules over 97 files, currently 0 findings), which runs in `check:all` and locally, and unlike CodeQL actually fails the build on findings.
- **The OWASP SARIF** is still published: the `upload-artifact` step immediately above the deleted one already uploads all of `reports/`, SARIF included.

Comments in place of both make the absence deliberate and reversible — if Code Security is ever enabled, they come back together.

Mirrors AFixt/a11y-mcp#138, which removed its CodeQL job for exactly this reason.

## Verification

Actions minutes are exhausted, so local runs are the source of truth.

| Check | Result |
|---|---|
| `actionlint` | ✅ **32 findings, identical to `develop`** — the pre-existing SC2086/SC2016 infos in `ci.yml`, untouched |
| workflow YAML parses | ✅ |
| `grep -n codeql .github/workflows/security.yml` | ✅ no matches |
| `npm run check` (lint, lint:css, lint:md, format:check, types:check) | ✅ exit 0 |
| `npm test` | ✅ 176/176, 15 suites |
| `npm run security:secrets` | ✅ 0 (pre-commit hook) |

## Note

Whether Code Security stays off is a repository-owner decision, not one this PR makes — it implements the decision already taken. If that has changed, close this and enable the setting instead; both steps then work as written.

Ready to merge pending CI restoration.
