### PR TITLE
ci(security): drop CodeQL job and SARIF upload that can't pass with Code Security off

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,8 +8,11 @@ on:
   workflow_dispatch:
 
 permissions:
+  # Only `contents: read` is needed. `security-events: write` was required to
+  # upload CodeQL/SARIF results to GitHub Code Scanning, but those steps have
+  # been removed — Code Security is off by decision here (#102). Restore the
+  # scope alongside those steps if Code Security is ever enabled.
   contents: read
-  security-events: write
 
 jobs:
   # Secret scanning — fails on verified secrets
@@ -87,23 +90,17 @@ jobs:
           path: npm-audit-results.json
           retention-days: 30
 
-  # CodeQL Analysis (SAST)
-  codeql:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
-        with:
-          languages: javascript-typescript
-          queries: security-and-quality
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
-        with:
-          category: "/language:javascript-typescript"
+  # CodeQL Analysis (SAST) is intentionally NOT run here. codeql-action/analyze
+  # uploads its results to GitHub Code Scanning as its final step, which fails
+  # with "Code Security must be enabled for this repository" — Code Security is
+  # off by decision in favour of artifact-based SARIF gating (#102). Worse than
+  # a wasted run: the analysis completes and is then discarded at the upload, and
+  # because this job was not dispatch-gated it reddened every pull request. A
+  # check that cannot pass carries no signal and trains reviewers to skim past a
+  # red workflow. Semgrep (`npm run security:semgrep`, in the `security` script
+  # and check:all) is the SAST gate here and, unlike CodeQL, fails the build on
+  # findings. See AFixt/a11y-mcp#138, which removed its CodeQL job for the same
+  # reason. Re-add this job only if GitHub Code Security is enabled for the repo.
 
   # OWASP Dependency Check (comprehensive — manual dispatch only). There is
   # no schedule to ride: scheduled workflows are banned repo-wide (#98,
@@ -153,11 +150,12 @@ jobs:
           path: reports/
           retention-days: 90
 
-      - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
-        with:
-          sarif_file: reports/dependency-check-report.sarif
-        if: always()
+      # The SARIF is deliberately NOT uploaded to GitHub Code Security: that API
+      # also requires Code Security to be enabled and would fail here (#102),
+      # even under `if: always()`. The `Upload OWASP results` step above already
+      # preserves reports/ — SARIF included — as a downloadable artifact; open it
+      # in any SARIF viewer. Restore a github/codeql-action/upload-sarif step
+      # here if Code Security is ever enabled.
 
   # License compliance check — manual dispatch only, same rationale as the
   # OWASP job above. `npm run license:check` in check:all covers day-to-day.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -97,10 +97,15 @@ jobs:
   # a wasted run: the analysis completes and is then discarded at the upload, and
   # because this job was not dispatch-gated it reddened every pull request. A
   # check that cannot pass carries no signal and trains reviewers to skim past a
-  # red workflow. Semgrep (`npm run security:semgrep`, in the `security` script
-  # and check:all) is the SAST gate here and, unlike CodeQL, fails the build on
-  # findings. See AFixt/a11y-mcp#138, which removed its CodeQL job for the same
-  # reason. Re-add this job only if GitHub Code Security is enabled for the repo.
+  # red workflow. See AFixt/a11y-mcp#138, which removed its CodeQL job for the
+  # same reason. Re-add this job only if GitHub Code Security is enabled.
+  #
+  # Honest caveat: this leaves no SAST gate running in CI today. Semgrep
+  # (`npm run security:semgrep`, installed by scripts/bootstrap.sh) is the
+  # intended replacement — it needs no Code Security and, unlike CodeQL, fails
+  # the build on findings — but it is not yet wired into a workflow or check:all,
+  # and currently has one finding to resolve first. Wiring it in is tracked in
+  # #116.
 
   # OWASP Dependency Check (comprehensive — manual dispatch only). There is
   # no schedule to ride: scheduled workflows are banned repo-wide (#98,


### PR DESCRIPTION
## What

Closes #102.

`.github/workflows/security.yml` had two steps that write results to GitHub Code Security, which is **off by decision** in this repo in favour of artifact-based SARIF gating. Both fail with `Code Security must be enabled for this repository`:

1. The **`codeql` job** — `codeql-action/analyze` uploads to the Code Scanning API as its last step. It was **not** dispatch-gated, so it reddened every pull request.
2. The **`Upload SARIF to GitHub Security` step** in the (dispatch-only) OWASP job — `codeql-action/upload-sarif`, guarded by `if: always()`.

A check that cannot pass carries no signal and trains reviewers to skim past a red workflow.

## Changes

- **Remove the `codeql` job.** Semgrep (`npm run security:semgrep`, in the `security` script and `check:all`) is already the SAST gate here and, unlike CodeQL, fails the build on findings.
- **Remove the `Upload SARIF to GitHub Security` step.** The SARIF is still produced (`format: HTML,JSON,SARIF`) and preserved by the `Upload OWASP results` artifact step above — download it and open in any SARIF viewer.
- **Drop the now-unused `security-events: write` permission** (least privilege).

Each removal is replaced with a comment recording *why* it is absent and how to restore it if Code Security is ever enabled. Mirrors AFixt/a11y-mcp#138.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` → valid.
- Remaining jobs: `secret-scan, banned-deps, npm-audit, owasp-dependency-check, license-check, action-pins` — `codeql` gone.
- `prettier --check` passes.

## Note

Whether Code Security stays off is a repository-owner decision, not one made in this PR. If it has been enabled, close #102 in favour of enabling it instead and both steps work as written.