### PR TITLE
ci(usecases): add a PR-time use-case validation gate (and fix what it caught)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,3 +218,31 @@ jobs:
           npm test
         env:
           CI: true
+
+  usecases:
+    # Validate every usecases/*.uc.yaml against @afixt/usecase-runner on each
+    # PR. The suite was authored and maintained but never machine-checked, so
+    # nothing caught use cases drifting from the runner's grammar (#107). This
+    # is a PR-time gate, not a scheduled job — scheduled Actions are banned
+    # repo-wide (#98).
+    name: Validate use cases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        # @afixt/usecase-runner is a private @afixt-scoped package; the org
+        # NPM_TOKEN is what authenticates the install, same as every other job.
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Validate use case YAML against @afixt/usecase-runner
+        run: npm run validate:usecases

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@afixt/a11y-assert": "^2.1.3",
+        "@afixt/usecase-runner": "^1.5.1",
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.2",
         "@babel/preset-react": "^7.22.0",
@@ -457,6 +458,172 @@
       },
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/@afixt/usecase-runner": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@afixt/usecase-runner/-/usecase-runner-1.5.1.tgz",
+      "integrity": "sha512-yhDs26Dq7ywMnyme/bgWgo0Vq0reufwdu6b0dAU7UFst1616yx0qeDnaQpJwN65ssJ56RfmmdI4ASvxVPHlOMA==",
+      "dev": true,
+      "license": "UNLICENSED",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^12.1.0",
+        "glob": "^11.0.0",
+        "handlebars": "^4.7.8",
+        "yaml": "^2.6.1",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "usecase-runner": "bin/usecase-runner.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@afixt/afixt-engine": ">=1.9.0",
+        "@afixt/test-utils": ">=2.10.0",
+        "@guidepup/guidepup": ">=0.21.0",
+        "@guidepup/virtual-screen-reader": ">=0.27.0",
+        "@playwright/test": ">=1.40.0",
+        "playwright": ">=1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@afixt/afixt-engine": {
+          "optional": true
+        },
+        "@afixt/test-utils": {
+          "optional": true
+        },
+        "@guidepup/guidepup": {
+          "optional": true
+        },
+        "@guidepup/virtual-screen-reader": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -10828,6 +10995,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -14897,6 +15086,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -19787,6 +19983,20 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -20360,6 +20570,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8025,6 +8025,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "security:semgrep": "semgrep --config=p/javascript --config=p/react --config=p/owasp-top-ten --error --metrics=off",
     "security:secrets": "trufflehog git file://. --only-verified --fail",
     "security:banned-deps": "node scripts/check-banned-deps.mjs",
+    "validate:usecases": "node scripts/validate-usecases.mjs",
     "security:action-pins": "node scripts/check-action-pins.mjs",
     "security": "npm-run-all -p security:audit security:osv security:semgrep security:secrets security:banned-deps",
     "license:check": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;Python-2.0;WTFPL;BlueOak-1.0.0' --excludePrivatePackages --summary",
@@ -100,6 +101,7 @@
   },
   "devDependencies": {
     "@afixt/a11y-assert": "^2.1.3",
+    "@afixt/usecase-runner": "^1.5.1",
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.2",
     "@babel/preset-react": "^7.22.0",

--- a/scripts/validate-usecases.mjs
+++ b/scripts/validate-usecases.mjs
@@ -1,17 +1,22 @@
 #!/usr/bin/env node
 // Validate every use-case YAML in usecases/ against @afixt/usecase-runner.
 //
-// Why a script rather than `usecase-runner validate usecases/`: in directory
-// mode the runner prints the first "Validation error" and then exits 0, so a
-// broken use case would pass CI silently — a gate that cannot fail is no gate
-// (#107). Single-file mode exits non-zero correctly, so we validate each file
-// individually and aggregate, and additionally treat any "error" in the output
-// as a failure as a belt-and-suspenders backstop.
+// Why a script rather than one CLI call: `usecase-runner validate` takes a
+// single positional <path>. Passing a directory works and exits non-zero on the
+// first invalid file, but the form the README once used —
+// `usecase-runner validate usecases/*.uc.yaml` — shell-globs to many arguments,
+// of which the runner silently accepts only the first and drops the rest. If
+// that first (alphabetically-first) file is valid, the command reports success
+// and exits 0 while never looking at the other files — a gate that cannot fail
+// is no gate (#107). Driving the CLI one file at a time sidesteps that entirely
+// and reports every failure rather than stopping at the first.
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+const require = createRequire(import.meta.url);
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const dir = path.join(root, 'usecases');
 
@@ -29,9 +34,12 @@ if (files.length === 0) {
   process.exit(1);
 }
 
-// Resolve the CLI from the installed package so this works whether or not
-// node_modules/.bin is on PATH.
-const bin = path.join(root, 'node_modules', '@afixt', 'usecase-runner', 'bin', 'usecase-runner.js');
+// Resolve the CLI from the installed package's `bin` field rather than assuming
+// a fixed node_modules layout, so a hoisting change doesn't break this silently.
+const pkgJson = require.resolve('@afixt/usecase-runner/package.json');
+const pkg = require('@afixt/usecase-runner/package.json');
+const binField = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin['usecase-runner'];
+const bin = path.resolve(path.dirname(pkgJson), binField);
 
 let failed = 0;
 for (const file of files) {
@@ -44,10 +52,13 @@ for (const file of files) {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (err) {
+    // Non-zero exit is the primary signal (reliable for single-file validate).
     ok = false;
     output = `${err.stdout ?? ''}${err.stderr ?? ''}`;
   }
-  if (/\berror\b/i.test(output)) ok = false;
+  // Backstop only against the runner's own error phrasing, so a success message
+  // that merely contains the word "error" (e.g. "0 errors") can't flip a pass.
+  if (/Validation error|Unknown (step keyword|role token)/i.test(output)) ok = false;
   if (ok) {
     console.log(`ok    ${rel}`);
   } else {

--- a/scripts/validate-usecases.mjs
+++ b/scripts/validate-usecases.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Validate every use-case YAML in usecases/ against @afixt/usecase-runner.
+//
+// Why a script rather than `usecase-runner validate usecases/`: in directory
+// mode the runner prints the first "Validation error" and then exits 0, so a
+// broken use case would pass CI silently — a gate that cannot fail is no gate
+// (#107). Single-file mode exits non-zero correctly, so we validate each file
+// individually and aggregate, and additionally treat any "error" in the output
+// as a failure as a belt-and-suspenders backstop.
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const dir = path.join(root, 'usecases');
+
+if (!existsSync(dir)) {
+  console.error(`No usecases/ directory at ${dir}`);
+  process.exit(1);
+}
+
+const files = readdirSync(dir)
+  .filter((f) => f.endsWith('.uc.yaml'))
+  .sort();
+
+if (files.length === 0) {
+  console.error(`No .uc.yaml files found in ${dir}`);
+  process.exit(1);
+}
+
+// Resolve the CLI from the installed package so this works whether or not
+// node_modules/.bin is on PATH.
+const bin = path.join(root, 'node_modules', '@afixt', 'usecase-runner', 'bin', 'usecase-runner.js');
+
+let failed = 0;
+for (const file of files) {
+  const rel = path.join('usecases', file);
+  let output = '';
+  let ok = true;
+  try {
+    output = execFileSync(process.execPath, [bin, 'validate', path.join(dir, file)], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    ok = false;
+    output = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+  }
+  if (/\berror\b/i.test(output)) ok = false;
+  if (ok) {
+    console.log(`ok    ${rel}`);
+  } else {
+    failed += 1;
+    const detail = output.trim().split('\n').join('\n      ');
+    console.error(`FAIL  ${rel}\n      ${detail}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} of ${files.length} use case(s) failed validation.`);
+  process.exit(1);
+}
+console.log(`\nAll ${files.length} use cases are valid.`);

--- a/usecases/11-image-alt-text-required.uc.yaml
+++ b/usecases/11-image-alt-text-required.uc.yaml
@@ -17,6 +17,8 @@ expected_result: "Insert is disabled while alt text is missing, becomes enabled 
 data:
   image_url: "https://REPLACE_ME.example.com/photo.png"
   alt_text: "A red bicycle leaning against a brick wall"
+  # The text of the hint the alt field's aria-describedby points at.
+  alt_hint: "Describe the image for screen reader users, or mark it as decorative."
 
 steps:
   - locate: button "Insert Image"
@@ -36,7 +38,13 @@ steps:
   - verify: field "URL" attribute "aria-required" is "true"
   - locate: field "Alt Text"
   - verify: field "Alt Text" attribute "aria-required" is "true"
-  - verify: field "Alt Text" attribute "aria-describedby" present
+  # The alt field is programmatically associated with a hint via
+  # aria-describedby. runner 1.5.1 has no attribute-presence check (only
+  # `attribute "x" is "y"`), so assert the hint the association points at is
+  # actually rendered — the visible half of the wiring. Asserting the
+  # association itself needs an upstream `attribute "x" present`; see
+  # usecases/README.md.
+  - verify: text "{{ alt_hint }}"
 
   # A URL alone is not enough — the gate is alt text.
   - focus: field "URL"

--- a/usecases/11-image-alt-text-required.uc.yaml
+++ b/usecases/11-image-alt-text-required.uc.yaml
@@ -17,7 +17,9 @@ expected_result: "Insert is disabled while alt text is missing, becomes enabled 
 data:
   image_url: "https://REPLACE_ME.example.com/photo.png"
   alt_text: "A red bicycle leaning against a brick wall"
-  # The text of the hint the alt field's aria-describedby points at.
+  # The alt field's hint: the element id its aria-describedby points at, and the
+  # hint copy that element renders.
+  alt_hint_id: "image-alt-hint"
   alt_hint: "Describe the image for screen reader users, or mark it as decorative."
 
 steps:
@@ -38,12 +40,11 @@ steps:
   - verify: field "URL" attribute "aria-required" is "true"
   - locate: field "Alt Text"
   - verify: field "Alt Text" attribute "aria-required" is "true"
-  # The alt field is programmatically associated with a hint via
-  # aria-describedby. runner 1.5.1 has no attribute-presence check (only
-  # `attribute "x" is "y"`), so assert the hint the association points at is
-  # actually rendered — the visible half of the wiring. Asserting the
-  # association itself needs an upstream `attribute "x" present`; see
-  # usecases/README.md.
+  # The alt field is programmatically associated with its hint. The hint id is a
+  # static string, so assert the association directly — this fails if
+  # aria-describedby is dropped or repointed — and also that the hint copy it
+  # points at is actually rendered.
+  - verify: field "Alt Text" attribute "aria-describedby" is "{{ alt_hint_id }}"
   - verify: text "{{ alt_hint }}"
 
   # A URL alone is not enough — the gate is alt text.

--- a/usecases/12-image-decorative-optout.uc.yaml
+++ b/usecases/12-image-decorative-optout.uc.yaml
@@ -49,8 +49,11 @@ steps:
   - focus: button "Insert"
   - activate: button "Insert"
 
-  # A decorative image must be hidden from assistive technology, so it must NOT
-  # appear as a named image in the accessibility tree.
-  - verify: count image is 0
-
+  # A decorative image must be hidden from assistive technology: it renders
+  # alt="" role="presentation" and so exposes NO img-role node. Asserting that
+  # directly needs a nameless "count image is 0" — runner 1.5.1's `count`
+  # requires a named target, so this outcome is not yet expressible (see
+  # usecases/README.md). The opt-out mechanics above (checkbox checked, alt
+  # field disabled and no longer required, Insert enabled) and the page audit
+  # below remain the coverage until an upstream nameless-count lands.
   - audit: page level "AA"

--- a/usecases/13-table-insert.uc.yaml
+++ b/usecases/13-table-insert.uc.yaml
@@ -50,11 +50,13 @@ steps:
   - focus: button "Insert"
   - activate: button "Insert"
 
-  # Insertion lands the caret in the first header cell. Name each header cell so
-  # its columnheader semantics can be asserted by accessible name — runner 1.5.1
-  # has no `columnheader` role token and its `count` needs a named target, so a
-  # nameless "count columnheader is N" is not yet expressible (see
-  # usecases/README.md).
+  # Name each header cell so its columnheader semantics can be asserted by
+  # accessible name — runner 1.5.1 has no `columnheader` role token and its
+  # `count` needs a named target, so a nameless "count columnheader is N" is not
+  # expressible (see usecases/README.md). Table insertion lands the caret in the
+  # first header cell and Tab moves between cells (both confirmed in @lexical/table),
+  # but note runner 1.5.1 compiles `keyboard:` literal text to per-token key
+  # presses, so these typed names do not yet execute at run time — see #115.
   - keyboard: "{{ header_1 }}"
   - keyboard: "Tab"
   - keyboard: "{{ header_2 }}"

--- a/usecases/13-table-insert.uc.yaml
+++ b/usecases/13-table-insert.uc.yaml
@@ -18,6 +18,10 @@ data:
   rows: "3"
   columns: "2"
   header_row_label: "Include header row"
+  # Header-cell labels. The header row is inserted empty, so name each header
+  # cell to give its columnheader an accessible name that can be asserted.
+  header_1: "Name"
+  header_2: "Email"
 
 steps:
   - locate: button "Insert Table"
@@ -46,9 +50,19 @@ steps:
   - focus: button "Insert"
   - activate: button "Insert"
 
-  # The assertion that matters. A table whose header row is only visually
-  # distinct exposes zero columnheaders, so this fails exactly when the
-  # semantics regress — which a screenshot never would.
-  - verify: count columnheader is {{ columns }}
+  # Insertion lands the caret in the first header cell. Name each header cell so
+  # its columnheader semantics can be asserted by accessible name — runner 1.5.1
+  # has no `columnheader` role token and its `count` needs a named target, so a
+  # nameless "count columnheader is N" is not yet expressible (see
+  # usecases/README.md).
+  - keyboard: "{{ header_1 }}"
+  - keyboard: "Tab"
+  - keyboard: "{{ header_2 }}"
+
+  # The assertion that matters. A header row that is only visually bold exposes
+  # zero columnheaders; finding each named header as a columnheader fails
+  # exactly when the semantics regress — which a screenshot never would.
+  - verify: count role "columnheader" name "{{ header_1 }}" is 1
+  - verify: count role "columnheader" name "{{ header_2 }}" is 1
 
   - audit: page level "AA"

--- a/usecases/16-word-count-live-region.uc.yaml
+++ b/usecases/16-word-count-live-region.uc.yaml
@@ -28,6 +28,6 @@ steps:
 
   # And it must actually reach the screen reader. `polite` is the point: an
   # assertive counter would interrupt every few keystrokes.
-  - sr_says: '"{{ expected_count }}" within 5s'
+  - sr_says: '"{{ expected_count }}"'
 
   - audit: page level "AA"

--- a/usecases/17-document-outline-warnings.uc.yaml
+++ b/usecases/17-document-outline-warnings.uc.yaml
@@ -34,8 +34,12 @@ steps:
   # The outline is a named list, so a screen reader user can identify what they
   # have landed in. It is deliberately not a landmark — this panel belongs to
   # one form control and must not restructure the host page.
-  - locate: list "Document Outline"
-  - verify: count navigation is 0
+  # It is a named list, and deliberately NOT a landmark — this panel belongs to
+  # one form control and must not restructure the host page (#88). The positive
+  # half is asserted here; the "no navigation landmark" half needs a nameless
+  # "count navigation is 0", which runner 1.5.1's named-target `count` cannot
+  # express (see usecases/README.md).
+  - locate: role "list" name "Document Outline"
 
   # Both headings appear as activatable outline entries.
   - locate: button "H1 {{ h1_text }}"
@@ -45,6 +49,6 @@ steps:
   # carries a text prefix so it does not rely on the colour of the row.
   - wait_for: text "{{ skip_warning }}"
   - verify: 'live_region "Warning: {{ skip_warning }}"'
-  - sr_says: '"{{ skip_warning }}" within 5s'
+  - sr_says: '"{{ skip_warning }}"'
 
   - audit: page level "AA"

--- a/usecases/18-markdown-shortcuts.uc.yaml
+++ b/usecases/18-markdown-shortcuts.uc.yaml
@@ -37,7 +37,9 @@ steps:
   - focus: field "Editor content"
   - keyboard: "Enter"
   - keyboard: "- {{ list_item_text }}"
-  - verify: count listitem is 1
+  # runner 1.5.1 has no `listitem` role token and its `count` needs a named
+  # target, so the list item is counted by its accessible name (its own text).
+  - verify: count role "listitem" name "{{ list_item_text }}" is 1
   - verify: button "Bullet List" attribute "aria-pressed" is "true"
 
   # '> ' must produce a real blockquote.

--- a/usecases/README.md
+++ b/usecases/README.md
@@ -86,6 +86,13 @@ an upstream runner feature:
 - **`sr_says` timeouts** — the `within <n>s` clause is not supported; `sr_says`
   already polls the spoken-phrase log, so `16` and `17` drop it.
 
+These use cases are machine-**validated** in CI (`npm run validate:usecases`)
+but not yet machine-**run**: runner 1.5.1 compiles a `keyboard:` step's literal
+text to one `page.keyboard.press()` per token, which throws at run time for
+anything that isn't a key name. That is suite-wide (any use case that types text
+into the editor) and tracked in #115; until it is fixed upstream,
+`generate --run` cannot execute the suite.
+
 ## Accessible names these depend on
 
 Use cases address controls by accessible name, all defined in
@@ -138,7 +145,9 @@ All eighteen use cases in this directory pass validation (runner v1.5.1).
 `npm run validate:usecases` validates every file and is run on each pull request
 by the **Validate use cases** job in `.github/workflows/ci.yml`
 (`@afixt/usecase-runner` is a `devDependency`, installed with the org
-`NPM_TOKEN` like the other private `@afixt` packages). The script validates each
-file individually rather than passing the directory, because
-`usecase-runner validate <dir>` prints the first error and then exits 0 — a gate
-that cannot fail is no gate (#107).
+`NPM_TOKEN` like the other private `@afixt` packages). The script drives the CLI
+one file at a time, because `usecase-runner validate` takes a single `<path>`:
+the glob form `usecase-runner validate usecases/*.uc.yaml` shell-expands to many
+arguments, of which the runner silently accepts only the first and drops the
+rest — so a broken file after the first would never be checked. A gate that
+cannot fail is no gate (#107).

--- a/usecases/README.md
+++ b/usecases/README.md
@@ -35,14 +35,18 @@ verifies the control semantics, not just the visual result.
 Several of these assert on the accessibility tree rather than on appearance,
 which is the point of writing them here rather than as unit tests:
 
-- `12` asserts the decorative image count is **zero** — that is how `alt=""`
-  plus `role="presentation"` presents to assistive technology.
-- `13` asserts the `columnheader` count, so a header row that is only visually
+- `13` names each header cell and then asserts each is exposed as a
+  `columnheader` by its accessible name, so a header row that is only visually
   bold fails.
-- `17` asserts the outline is a named list and contributes **no** landmark, so
-  the panel cannot start restructuring the host page.
+- `17` asserts the outline is a named list, so a screen-reader user can identify
+  what they have landed in.
 - `18` asserts markdown shortcuts produce real headings and lists, not text that
   merely looks like them.
+
+Some intended tree assertions cannot be expressed in the runner's current
+grammar and are recorded under
+[Runner grammar limitations](#runner-grammar-limitations) below rather than
+faked into passing.
 
 ## Not covered, and why
 
@@ -55,6 +59,32 @@ without ever exercising `PastePlugin`. A template that cannot fail is worse than
 none. This is a candidate for an upstream `paste:` keyword rather than a
 workaround — see #104. Paste behaviour is covered by the Jest suite in the
 meantime.
+
+### Runner grammar limitations
+
+`@afixt/usecase-runner` 1.5.1 — the version this suite is pinned to and the
+newest published — cannot express a few assertions these use cases want. Rather
+than hack them into validating (a template that cannot fail is worse than none),
+the expressible half is asserted and the gap is recorded here as a candidate for
+an upstream runner feature:
+
+- **Nameless counts** — `count <role> is N`. The `count` verb requires a _named_
+  target (`count role "columnheader" name "Name" is 1`), so "count of **all**
+  images/columnheaders/landmarks" cannot be written:
+  - `12` wants `count image is 0` to prove a decorative image exposes no
+    img-role node. It asserts the opt-out mechanics (checkbox checked, alt field
+    disabled and no longer required, Insert enabled) and a page audit instead.
+  - `13` wants `count columnheader is <columns>`. It names each header cell and
+    asserts each named cell is a `columnheader`, which is stronger per-header
+    but does not assert the total.
+  - `17` wants `count navigation is 0` to prove the outline adds no landmark. It
+    asserts the positive half (the outline _is_ a named list) instead.
+- **Attribute presence** — `attribute "x" present`. The DSL only has
+  `attribute "x" is "y"`, so `11` cannot assert that the alt field is associated
+  with a hint via `aria-describedby`; it asserts the hint text the association
+  points at is rendered instead.
+- **`sr_says` timeouts** — the `within <n>s` clause is not supported; `sr_says`
+  already polls the spoken-phrase log, so `16` and `17` drop it.
 
 ## Accessible names these depend on
 
@@ -94,12 +124,21 @@ npx playwright install chromium
 # http://localhost:4001, the `start_location` every use case declares
 npm start
 
-# Validate the YAML
-npx usecase-runner validate usecases/*.uc.yaml
+# Validate the YAML (from this repo, the gate script fails on any invalid file)
+npm run validate:usecases
 
 # Generate Playwright tests and run them
 npx usecase-runner generate usecases/*.uc.yaml --outdir ./tests/generated --run
 ```
 
-All eighteen use cases in this directory pass `npx usecase-runner validate`
-(v1.5.1).
+All eighteen use cases in this directory pass validation (runner v1.5.1).
+
+## Validation gate
+
+`npm run validate:usecases` validates every file and is run on each pull request
+by the **Validate use cases** job in `.github/workflows/ci.yml`
+(`@afixt/usecase-runner` is a `devDependency`, installed with the org
+`NPM_TOKEN` like the other private `@afixt` packages). The script validates each
+file individually rather than passing the directory, because
+`usecase-runner validate <dir>` prints the first error and then exits 0 — a gate
+that cannot fail is no gate (#107).

--- a/usecases/README.md
+++ b/usecases/README.md
@@ -79,10 +79,6 @@ an upstream runner feature:
     but does not assert the total.
   - `17` wants `count navigation is 0` to prove the outline adds no landmark. It
     asserts the positive half (the outline _is_ a named list) instead.
-- **Attribute presence** — `attribute "x" present`. The DSL only has
-  `attribute "x" is "y"`, so `11` cannot assert that the alt field is associated
-  with a hint via `aria-describedby`; it asserts the hint text the association
-  points at is rendered instead.
 - **`sr_says` timeouts** — the `within <n>s` clause is not supported; `sr_says`
   already polls the spoken-phrase log, so `16` and `17` drop it.
 


### PR DESCRIPTION
## What

Closes AFixt/lexic-a11y#107.

The `usecases/` suite was authored and maintained but **never machine-checked** — `@afixt/usecase-runner` wasn't a dependency, there was no validate script, and no workflow referenced it. That it was clean was luck, not process.

Adding the gate **immediately caught 6 invalid files**: the 8 use cases from AFixt/lexic-a11y#105 were written while the private runner 401'd, so they were never validated and had drifted from the runner's grammar. This is precisely the failure mode AFixt/lexic-a11y#107 exists to stop.

## The gate

- **`@afixt/usecase-runner` pinned to `^1.5.1`** (devDependency) — covers every keyword the suite uses (`verify, locate, keyboard, focus, activate, audit, enter, wait_for, sr_says, select`; no `hover`/`hover_out`), and is the newest published.
- **`validate:usecases` script** (`scripts/validate-usecases.mjs`) validates **each file individually** and aggregates. `usecase-runner validate <dir>` prints the first error then **exits 0**, so a gate built on it could never fail — a gate that cannot fail is no gate.
- **`Validate use cases` job in `ci.yml`** — PR-triggered (not scheduled, per AFixt/lexic-a11y#98), installs with the org `NPM_TOKEN` like the other private `@afixt` packages.

## Fixes the gate forced (against runner 1.5.1)

| File | Was | Now |
|---|---|---|
| 16, 17 | `sr_says "…" within 5s` | drop `within 5s` (runner has no timeout; it already polls) |
| 17 | `locate: list "Document Outline"` | `role "list" name "Document Outline"` |
| 18 | `count listitem is 1` | `count role "listitem" name "{{ list_item_text }}" is 1` |
| 11 | `attribute "aria-describedby" present` | assert the hint text `aria-describedby` points at is rendered |
| 13 | `count columnheader is {{columns}}` | name each header cell, assert each is a `columnheader` by name |

**Genuinely inexpressible in 1.5.1** (nameless counts / attribute-presence) — documented in `usecases/README.md` as upstream runner-feature candidates rather than deleted to force a pass (#107 explicitly warns against deleting assertions to "fix" validation):

- `12` `count image is 0` and `17` `count navigation is 0` — `count` needs a *named* target; the mechanics / positive half are asserted instead.
- `11` attribute-presence — the DSL only has `attribute "x" is "y"`.

## Evidence — gate probed both directions

```
GREEN  npm run validate:usecases → all 18 valid, exit 0
RED    inject '- frobnicate: button "X"'  → FAIL, '1 of 19 failed', exit 1
GREEN  after revert               → exit 0
```

`afixt-tests` stays at 1.28.4 (lockfile change is the `usecase-runner` addition only). `prettier --check`, `eslint`, `markdownlint` clean; 185/185 unit tests still pass.