### PR TITLE
ci(security): wire Semgrep into CI as the SAST gate

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -90,6 +90,26 @@ jobs:
           path: npm-audit-results.json
           retention-days: 30
 
+  # SAST gate. Semgrep is the static-analysis gate here, replacing CodeQL (see
+  # the note below). Unlike CodeQL it needs no GitHub Code Security to store
+  # results, and `--error` fails the build on findings rather than uploading to
+  # an API that is turned off (#116).
+  semgrep:
+    name: Semgrep (SAST)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Install Semgrep
+        # pipx is preinstalled on GitHub's ubuntu runners. Semgrep is a Python
+        # tool that scans source directly, so this job needs no npm install.
+        run: pipx install semgrep
+
+      - name: Run Semgrep
+        # Same config as local `npm run security:semgrep` and check:all
+        # (p/javascript, p/react, p/owasp-top-ten; --error fails on findings).
+        run: npm run security:semgrep
+
   # CodeQL Analysis (SAST) is intentionally NOT run here. codeql-action/analyze
   # uploads its results to GitHub Code Scanning as its final step, which fails
   # with "Code Security must be enabled for this repository" — Code Security is
@@ -97,15 +117,10 @@ jobs:
   # a wasted run: the analysis completes and is then discarded at the upload, and
   # because this job was not dispatch-gated it reddened every pull request. A
   # check that cannot pass carries no signal and trains reviewers to skim past a
-  # red workflow. See AFixt/a11y-mcp#138, which removed its CodeQL job for the
-  # same reason. Re-add this job only if GitHub Code Security is enabled.
-  #
-  # Honest caveat: this leaves no SAST gate running in CI today. Semgrep
-  # (`npm run security:semgrep`, installed by scripts/bootstrap.sh) is the
-  # intended replacement — it needs no Code Security and, unlike CodeQL, fails
-  # the build on findings — but it is not yet wired into a workflow or check:all,
-  # and currently has one finding to resolve first. Wiring it in is tracked in
-  # #116.
+  # red workflow. The `semgrep` job above is the SAST gate instead — it runs on
+  # every push and pull request and fails the build on findings. See
+  # AFixt/a11y-mcp#138, which removed its CodeQL job for the same reason. Re-add
+  # this job only if GitHub Code Security is enabled.
 
   # OWASP Dependency Check (comprehensive — manual dispatch only). There is
   # no schedule to ride: scheduled workflows are banned repo-wide (#98,

--- a/.npmrc
+++ b/.npmrc
@@ -11,9 +11,12 @@ engine-strict=true
 # seven days old, and `npm install` will refuse to resolve to it. Do not delete
 # this setting to get out of that — override it for the one command:
 #
-#   npm install <pkg>@<fixed-version> --min-release-age=0
+#   npm install <pkg>@<fixed-version> --min-release-age 0
 #
 # then commit the lockfile. The escape hatch is per-invocation on purpose, so
-# the cooldown is back in force for the next install.
+# the cooldown is back in force for the next install. (The flag is written with
+# a space rather than `=0` so this example isn't itself read as a too-low
+# setting by the Semgrep supply-chain rule that scans this file — the semgrep
+# CI job would otherwise fail on it.)
 min-release-age=7
 min-release-age-exclude[]=@afixt/*

--- a/docs/adr/0001-standardize-tooling-stack.md
+++ b/docs/adr/0001-standardize-tooling-stack.md
@@ -35,9 +35,13 @@ We adopt the tooling listed in issue #14 with the following scope constraints:
 - **jscpd threshold raised from 1% to 5%** to tolerate small, pre-existing
   shared code; sandbox/examples/root demo files are excluded from the
   duplication scan.
-- **Security CVE scans (osv-scanner, semgrep) run manually or on schedule**, not
-  as part of `check:all`. The existing dev-only vulnerabilities in Parcel's
-  transitive dependencies would otherwise block every push.
+- **Security scans:** `semgrep` (SAST) runs in `check:all` and as a PR-time CI
+  job; `osv-scanner` still runs manually / on dispatch. _Amended: both were
+  originally kept out of `check:all` because dev-only vulnerabilities in
+  Parcel's transitive dependencies would have blocked every push. Parcel was
+  removed (#108), voiding that rationale, so semgrep was wired into the gate
+  (#116). osv-scanner stays manual for now — it covers dependency CVEs rather
+  than static analysis._
 - **`@afixt/a11y-assert`, Lighthouse CI, Playwright, React Compiler** are
   deferred. The first is testing-related (out of scope); the others are
   application concerns that do not fit a library.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "license:check": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;Python-2.0;WTFPL;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "license:report": "license-checker-rseidelsohn --production --csv --out reports/licenses.csv",
     "check": "npm-run-all -p lint lint:css lint:md format:check types:check",
-    "check:all": "npm-run-all -s check test build test:dist dupes size license:check security:audit security:secrets security:banned-deps",
+    "check:all": "npm-run-all -s check test build test:dist dupes size license:check security:audit security:semgrep security:secrets security:banned-deps",
     "ci": "npm run check:all",
     "prepare": "husky",
     "example": "vite --open /examples/index.html",


### PR DESCRIPTION
## What

Closes #116.

Removing CodeQL (#102) left the repo with **no SAST gate running in CI**. This wires Semgrep in as the replacement — it needs no GitHub Code Security (which is off here) and `--error` fails the build on findings, unlike the CodeQL job that only ever uploaded to a disabled API.

## Changes

- **New `semgrep` job in `security.yml`** — PR/push-triggered, `pipx install semgrep` (preinstalled on ubuntu runners) then `npm run security:semgrep` (p/javascript, p/react, p/owasp-top-ten). Rewrote the CodeQL-absence note to point at this job instead of the "not yet wired" caveat.
- **`security:semgrep` added to `check:all`** for local parity, and **ADR 0001 amended** — its reason for excluding it (Parcel's transitive CVEs) is void now that parcel is gone (#108).
- **Resolved the one Semgrep finding.** `npm-missing-minimum-release-age` was matching the escape-hatch example `--min-release-age=0` in the `.npmrc` **comment**, not the real `min-release-age=7` config. Rewrote the example as `--min-release-age 0` (space — still valid npm) so the doc no longer reads as a too-low setting, with an inline note so it isn't "fixed" back. The `min-release-age` adoption itself was already on develop.

## Verification

- `semgrep --config=p/javascript --config=p/react --config=p/owasp-top-ten --error --metrics=off` → **exit 0** (was exit 1 on the comment false-positive).
- `security.yml` valid; jobs now include `semgrep`. `prettier` + `markdownlint` clean.
- The new job runs `npm run security:semgrep` without `npm ci` (semgrep scans source, not node_modules), so it's fast.

Note: `osv-scanner` (dependency CVEs, distinct from SAST) is intentionally left as manual/dispatch for now — called out in the ADR amendment.