### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/lexic-a11y",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@lexical/code": "0.12.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/lexic-a11y",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "description": "A fully featured, accessible, and internationalized rich text editor built with React and Lexical",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Version bump 2.0.0 → **2.2.0** (package.json + package-lock.json only).

Skips the never-published, never-tagged **2.1.0** that was left orphaned on `main` (#96; npm `latest` was 2.0.0) — reconciled into develop in #118.

Ships the work since v2.0.0: use-case validation gate (#107), a11y advisory-rule filter (#101), unused parcel removal (#108), honest engines.node floor + CI floor job (#109), CodeQL removal (#102), Semgrep SAST gate (#116), scheduled-automation removal (#98), markdown code-shortcut fix, and e2e contrast tests. No public API change; `engines.node` floor raised (dev-tooling-driven, treated as non-breaking → minor).