### PR TITLE
docs(ci): correct the Dependabot alerts claim in the CI policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,9 @@ a pull request blocks the defect at the point of introduction.
 
 - No `on: schedule:` and no `- cron:` in any file under `.github/workflows/`.
 - No `.github/dependabot.yml` — Dependabot is a scheduled updater and is covered
-  by this policy (removed in #98). GitHub **security alerts** are event-driven
-  notifications, not scheduled jobs, and remain enabled.
+  by this policy (removed in #98). Dependabot **security alerts** and
+  **automated security fixes** are switched off at the repository level
+  too — verified by API on 2026-08-16.
 - Dependabot's one real job here — refreshing the SHA-pinned action references —
   is owned by the `Action Pin Freshness` job in `security.yml`
   (`npm run security:action-pins` locally). It is `workflow_dispatch` only:


### PR DESCRIPTION
## What

`CLAUDE.md`'s no-scheduled-Actions policy claimed Dependabot security alerts "remain enabled". They are not.

```
GET /repos/AFixt/<this-repo>/vulnerability-alerts     -> HTTP 404 (disabled)
GET /repos/AFixt/<this-repo>/automated-security-fixes -> {"enabled": false}
```

Verified on this repository specifically on 2026-08-16, not generalised from a sample. A survey of all 131 active AFixt repos found 56 carrying this sentence; checking each one individually turned up exactly one (`meetabl-ui`) where alerts genuinely are enabled, and that repo is deliberately excluded.

Not a permissions artifact: the token carries `repo` scope and reports `admin: true`, and reads `automated-security-fixes` cleanly on the same repositories.

## Why it matters

The sentence reads as a safety net — it says the scheduled updater was removed but event-driven alerting still watches the tree between pushes. Nothing does. Anyone reasoning from it concludes dependency drift is covered when it is not.

That is not hypothetical: AFixt/batch-scanner#46 was a CVSS 8.6 advisory sitting undetected against an unchanged lockfile until someone tried to push and the pre-push gate failed on it.

## Change

Docs only, one paragraph. States that alerts and automated fixes are both off, dates the claim to the check that supports it, and says plainly that the PR pipeline is the only remaining place a vulnerable dependency gets caught.

Deliberately does **not** name specific npm scripts or cite a batch-scanner issue number, unlike the version in that repo — those are per-repo facts that would need verifying here before asserting them. Fixing an unverified claim with another unverified claim would defeat the purpose.

## Note on CI

Checks on this PR will fail without starting: *"The job was not started because an Actions budget is preventing further use."* That affects every PR in the org right now and is unrelated to this change, which touches one markdown paragraph and no code, workflows, or dependencies.

Part of AFixt/batch-scanner#44 (step 7).