### PR TITLE
chore(npm): make published package visibility explicit

### DIFF
--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -1,6 +1,7 @@
 {
   "name": "lexic-a11y-sandbox",
   "version": "1.0.0",
+  "private": true,
   "description": "CodeSandbox demo for lexic-a11y",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Mechanical npm publish-configuration change, part of a fleet-wide sweep.

- Removes the deprecated `always-auth` setting (npm 11 reports it as an unknown project config and ignores it).

- Makes publish visibility explicit so a bare `npm publish` is correct and cannot be flipped public by a stray `--access public`.